### PR TITLE
Fix Handler bug borrowing too much

### DIFF
--- a/src/IonPool.sol
+++ b/src/IonPool.sol
@@ -493,9 +493,7 @@ contract IonPool is IonPausableUpgradeable, RewardModule {
         whenNotPaused(Pauses.UNSAFE)
         onlyWhitelistedBorrowers(ilkIndex, proof)
     {
-        console.log("accurding");
         _accrueInterestForIlk(ilkIndex);
-        console.log("1accurding");
         (uint104 ilkRate, uint256 newDebt) =
             _modifyPosition(ilkIndex, user, address(0), recipient, 0, amountOfNormalizedDebt.toInt256());
 

--- a/src/YieldOracle.sol
+++ b/src/YieldOracle.sol
@@ -54,8 +54,6 @@ contract YieldOracle is IYieldOracle, Ownable2Step {
     address public immutable ADDRESS1;
     address public immutable ADDRESS2;
 
-    event H(uint256 prev, uint256 next);
-
     IonPool public ionPool;
 
     uint32 public currentIndex;
@@ -97,13 +95,10 @@ contract YieldOracle is IYieldOracle, Ownable2Step {
         for (uint8 i = 0; i < ILK_COUNT;) {
             uint64 newExchangeRate = _getExchangeRate(i);
             uint64 previousExchangeRate = previousExchangeRates[i];
-            console.log(newExchangeRate, previousExchangeRate);
 
             if (newExchangeRate == 0 || newExchangeRate < previousExchangeRate) revert InvalidExchangeRate(i);
 
             uint256 exchangeRateIncrease = newExchangeRate - previousExchangeRate;
-
-            emit H(previousExchangeRate, newExchangeRate);
 
             // [WAD] * [APY_PRECISION] / [WAD] = [APY_PRECISION]
             uint32 newApy = exchangeRateIncrease.mulDiv(PERIODS, previousExchangeRate).toUint32();
@@ -115,9 +110,7 @@ contract YieldOracle is IYieldOracle, Ownable2Step {
             emit ApyUpdate(i, newApy);
 
             // forgefmt: disable-next-line
-            unchecked {
-                ++i;
-            }
+            unchecked { ++i; }
         }
 
         // update Apy, history with new exchangeRates, and currentIndex

--- a/src/flash/handlers/base/IonHandlerBase.sol
+++ b/src/flash/handlers/base/IonHandlerBase.sol
@@ -104,12 +104,14 @@ abstract contract IonHandlerBase {
         ionPool.depositCollateral(ilkIndex, vaultHolder, address(this), amountCollateral, new bytes32[](0));
 
         uint256 currentRate = ionPool.rate(ilkIndex);
+        (,, uint256 newRateIncrease,,) = ionPool.calculateRewardAndDebtDistribution(ilkIndex);
+        uint256 rateAfterAccrual = currentRate + newRateIncrease;
 
         uint256 normalizedAmountToBorrow;
         if (amountToBorrowType == AmountToBorrow.IS_MIN) {
-            normalizedAmountToBorrow = amountToBorrow.rayDivUp(currentRate);
+            normalizedAmountToBorrow = amountToBorrow.rayDivUp(rateAfterAccrual);
         } else {
-            normalizedAmountToBorrow = amountToBorrow.rayDivDown(currentRate);
+            normalizedAmountToBorrow = amountToBorrow.rayDivDown(rateAfterAccrual);
         }
 
         if (amountToBorrow != 0) {
@@ -135,7 +137,10 @@ abstract contract IonHandlerBase {
         internal
     {
         uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 normalizedDebtToRepay = debtToRepay.rayDivDown(currentRate);
+        (,, uint256 newRateIncrease,,) = ionPool.calculateRewardAndDebtDistribution(ilkIndex);
+        uint256 rateAfterAccrual = currentRate + newRateIncrease;
+
+        uint256 normalizedDebtToRepay = debtToRepay.rayDivDown(rateAfterAccrual);
 
         ionPool.repay(ilkIndex, vaultHolder, address(this), normalizedDebtToRepay);
 

--- a/test/fork/concrete/EthXHandlerFork.t.sol
+++ b/test/fork/concrete/EthXHandlerFork.t.sol
@@ -65,8 +65,12 @@ contract EthXHandler_ForkTest is EthXHandler_ForkBase {
         uint256 gasAfter = gasleft();
         if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertGe(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), resultingDebt);
         assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(ethXHandler)), 0);
+        assertLe(weth.balanceOf(address(ethXHandler)), roundingError);
         assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
     }
 
@@ -83,12 +87,16 @@ contract EthXHandler_ForkTest is EthXHandler_ForkBase {
         uint256 gasAfter = gasleft();
         if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertApproxEqAbs(
             ionPool.normalizedDebt(ilkIndex, address(this)).rayMulDown(ionPool.rate(ilkIndex)),
             resultingDebt,
             1e27 / RAY
         );
         assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(ethXHandler)), 0);
+        assertLe(weth.balanceOf(address(ethXHandler)), roundingError);
         assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
     }
 
@@ -105,8 +113,12 @@ contract EthXHandler_ForkTest is EthXHandler_ForkBase {
         uint256 gasAfter = gasleft();
         if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
         assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(ethXHandler)), 0);
+        assertLe(weth.balanceOf(address(ethXHandler)), roundingError);
         assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
     }
 
@@ -149,8 +161,13 @@ contract EthXHandler_ForkTest is EthXHandler_ForkBase {
         uint256 gasAfter = gasleft();
         if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertGe(ionPool.collateral(ilkIndex, address(this)), resultingCollateral - maxCollateralToRemove);
         assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), 0);
+        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(ethXHandler)), 0);
+        assertLe(weth.balanceOf(address(ethXHandler)), roundingError);
     }
 
     function testFork_RevertWhen_BalancerFlashloanNotInitiatedByHandler() external {

--- a/test/fork/concrete/SwEthHandlerFork.t.sol
+++ b/test/fork/concrete/SwEthHandlerFork.t.sol
@@ -71,8 +71,12 @@ contract SwEthHandler_ForkTest is SwEthHandler_ForkBase {
         uint256 gasAfter = gasleft();
         if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertGe(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), resultingDebt);
         assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(swEthHandler)), 0);
+        assertLe(weth.balanceOf(address(swEthHandler)), roundingError);
         assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
     }
 
@@ -89,12 +93,16 @@ contract SwEthHandler_ForkTest is SwEthHandler_ForkBase {
         uint256 gasAfter = gasleft();
         if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertApproxEqAbs(
             ionPool.normalizedDebt(ilkIndex, address(this)).rayMulDown(ionPool.rate(ilkIndex)),
             resultingDebt,
             1e27 / RAY
         );
         assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(swEthHandler)), 0);
+        assertLe(weth.balanceOf(address(swEthHandler)), roundingError);
         assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
     }
 
@@ -111,8 +119,12 @@ contract SwEthHandler_ForkTest is SwEthHandler_ForkBase {
         uint256 gasAfter = gasleft();
         if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
         assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(swEthHandler)), 0);
+        assertLe(weth.balanceOf(address(swEthHandler)), roundingError);
         assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
     }
 
@@ -152,8 +164,13 @@ contract SwEthHandler_ForkTest is SwEthHandler_ForkBase {
 
         swEthHandler.flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertGe(ionPool.collateral(ilkIndex, address(this)), resultingCollateral - maxCollateralToRemove);
         assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), 0);
+        assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(swEthHandler)), 0);
+        assertLe(weth.balanceOf(address(swEthHandler)), roundingError);
     }
 
     function testFork_RevertWhen_FlashloanNotInitiatedByHandler() external {

--- a/test/fork/concrete/WstEthHandlerFork.t.sol
+++ b/test/fork/concrete/WstEthHandlerFork.t.sol
@@ -71,8 +71,12 @@ contract WstEthHandler_ForkTest is WstEthHandler_ForkBase {
         uint256 gasAfter = gasleft();
         if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertGe(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), resultingDebt);
         assertEq(IERC20(address(MAINNET_WSTETH)).balanceOf(address(wstEthHandler)), 0);
+        assertLe(weth.balanceOf(address(wstEthHandler)), roundingError);
         assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
     }
 
@@ -89,12 +93,16 @@ contract WstEthHandler_ForkTest is WstEthHandler_ForkBase {
         uint256 gasAfter = gasleft();
         if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertApproxEqAbs(
             ionPool.normalizedDebt(ilkIndex, address(this)).rayMulDown(ionPool.rate(ilkIndex)),
             resultingDebt,
             1e27 / RAY
         );
         assertEq(IERC20(address(MAINNET_WSTETH)).balanceOf(address(wstEthHandler)), 0);
+        assertLe(weth.balanceOf(address(wstEthHandler)), roundingError);
         assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
     }
 
@@ -111,8 +119,12 @@ contract WstEthHandler_ForkTest is WstEthHandler_ForkBase {
         uint256 gasAfter = gasleft();
         if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
         assertEq(IERC20(address(MAINNET_WSTETH)).balanceOf(address(wstEthHandler)), 0);
+        assertLe(weth.balanceOf(address(wstEthHandler)), roundingError);
         assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
     }
 
@@ -152,8 +164,13 @@ contract WstEthHandler_ForkTest is WstEthHandler_ForkBase {
 
         wstEthHandler.flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertGe(ionPool.collateral(ilkIndex, address(this)), resultingCollateral - maxCollateralToRemove);
         assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), 0);
+        assertEq(IERC20(address(MAINNET_WSTETH)).balanceOf(address(wstEthHandler)), 0);
+        assertLe(weth.balanceOf(address(wstEthHandler)), roundingError);
     }
 
     function testFork_RevertWhen_FlashloanNotInitiatedByHandler() external {

--- a/test/fork/fuzz/EthXHandlerForkFuzz.t.sol
+++ b/test/fork/fuzz/EthXHandlerForkFuzz.t.sol
@@ -45,8 +45,12 @@ abstract contract EthXHandler_ForkFuzzTest is EthXHandler_ForkBase {
 
         ethXHandler.flashLeverageCollateral(initialDeposit, resultingCollateral, resultingDebt);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertGe(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), resultingDebt);
         assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(ethXHandler)), 0);
+        assertLe(weth.balanceOf(address(ethXHandler)), roundingError);
         assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
     }
 
@@ -68,12 +72,16 @@ abstract contract EthXHandler_ForkFuzzTest is EthXHandler_ForkBase {
 
         ethXHandler.flashLeverageWeth(initialDeposit, resultingCollateral, resultingDebt);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertApproxEqAbs(
             ionPool.normalizedDebt(ilkIndex, address(this)).rayMulDown(ionPool.rate(ilkIndex)),
             resultingDebt,
             ilkRate / RAY
         );
         assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(ethXHandler)), 0);
+        assertLe(weth.balanceOf(address(ethXHandler)), roundingError);
         assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
     }
 
@@ -88,8 +96,12 @@ abstract contract EthXHandler_ForkFuzzTest is EthXHandler_ForkBase {
 
         ethXHandler.flashLeverageWethAndSwap(initialDeposit, resultingCollateral, maxResultingDebt);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
         assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(ethXHandler)), 0);
+        assertLe(weth.balanceOf(address(ethXHandler)), roundingError);
         assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
     }
 
@@ -130,8 +142,13 @@ abstract contract EthXHandler_ForkFuzzTest is EthXHandler_ForkBase {
 
         ethXHandler.flashDeleverageWethAndSwap(maxCollateralToRemove, debtToRemove);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertGe(ionPool.collateral(ilkIndex, address(this)), resultingCollateral - maxCollateralToRemove);
         assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), 0);
+        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(ethXHandler)), 0);
+        assertLe(weth.balanceOf(address(ethXHandler)), roundingError);
     }
 }
 

--- a/test/fork/fuzz/SwEthHandlerForkFuzz.t.sol
+++ b/test/fork/fuzz/SwEthHandlerForkFuzz.t.sol
@@ -35,8 +35,12 @@ abstract contract SwEthHandler_ForkFuzzTest is SwEthHandler_ForkBase {
 
         swEthHandler.flashLeverageCollateral(initialDeposit, resultingCollateral, resultingDebt);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertGe(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), resultingDebt);
         assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(swEthHandler)), 0);
+        assertLe(weth.balanceOf(address(swEthHandler)), roundingError);
         assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
     }
 
@@ -58,12 +62,16 @@ abstract contract SwEthHandler_ForkFuzzTest is SwEthHandler_ForkBase {
 
         swEthHandler.flashLeverageWeth(initialDeposit, resultingCollateral, resultingDebt);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertApproxEqAbs(
             ionPool.normalizedDebt(ilkIndex, address(this)).rayMulDown(ionPool.rate(ilkIndex)),
             resultingDebt,
             ilkRate / RAY
         );
         assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(swEthHandler)), 0);
+        assertLe(weth.balanceOf(address(swEthHandler)), roundingError);
         assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
     }
 
@@ -78,8 +86,12 @@ abstract contract SwEthHandler_ForkFuzzTest is SwEthHandler_ForkBase {
 
         swEthHandler.flashswapLeverage(initialDeposit, resultingCollateral, maxResultingDebt, sqrtPriceLimitX96);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
         assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(swEthHandler)), 0);
+        assertLe(weth.balanceOf(address(swEthHandler)), roundingError);
         assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
     }
 
@@ -120,8 +132,13 @@ abstract contract SwEthHandler_ForkFuzzTest is SwEthHandler_ForkBase {
 
         swEthHandler.flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertGe(ionPool.collateral(ilkIndex, address(this)), resultingCollateral - maxCollateralToRemove);
         assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), 0);
+        assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(swEthHandler)), 0);
+        assertLe(weth.balanceOf(address(swEthHandler)), roundingError);
     }
 }
 

--- a/test/fork/fuzz/WstEthHandlerForkFuzz.t.sol
+++ b/test/fork/fuzz/WstEthHandlerForkFuzz.t.sol
@@ -35,8 +35,12 @@ abstract contract WstEthHandler_ForkFuzzTest is WstEthHandler_ForkBase {
 
         wstEthHandler.flashLeverageCollateral(initialDeposit, resultingCollateral, resultingDebt);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertGe(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), resultingDebt);
         assertEq(IERC20(address(MAINNET_WSTETH)).balanceOf(address(wstEthHandler)), 0);
+        assertLe(weth.balanceOf(address(wstEthHandler)), roundingError);
         assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
     }
 
@@ -58,12 +62,16 @@ abstract contract WstEthHandler_ForkFuzzTest is WstEthHandler_ForkBase {
 
         wstEthHandler.flashLeverageWeth(initialDeposit, resultingCollateral, resultingDebt);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertApproxEqAbs(
             ionPool.normalizedDebt(ilkIndex, address(this)).rayMulDown(ionPool.rate(ilkIndex)),
             resultingDebt,
             ilkRate / RAY
         );
         assertEq(IERC20(address(MAINNET_WSTETH)).balanceOf(address(wstEthHandler)), 0);
+        assertLe(weth.balanceOf(address(wstEthHandler)), roundingError);
         assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
     }
 
@@ -78,8 +86,12 @@ abstract contract WstEthHandler_ForkFuzzTest is WstEthHandler_ForkBase {
 
         wstEthHandler.flashswapLeverage(initialDeposit, resultingCollateral, maxResultingDebt, sqrtPriceLimitX96);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
         assertEq(IERC20(address(MAINNET_WSTETH)).balanceOf(address(wstEthHandler)), 0);
+        assertLe(weth.balanceOf(address(wstEthHandler)), roundingError);
         assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
     }
 
@@ -120,8 +132,13 @@ abstract contract WstEthHandler_ForkFuzzTest is WstEthHandler_ForkBase {
 
         wstEthHandler.flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0);
 
+        uint256 currentRate = ionPool.rate(ilkIndex);
+        uint256 roundingError = currentRate / RAY;
+
         assertGe(ionPool.collateral(ilkIndex, address(this)), resultingCollateral - maxCollateralToRemove);
         assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), 0);
+        assertEq(IERC20(address(MAINNET_WSTETH)).balanceOf(address(wstEthHandler)), 0);
+        assertLe(weth.balanceOf(address(wstEthHandler)), roundingError);
     }
 }
 


### PR DESCRIPTION
This will lead to less loss of funds for leverager's tokens ending up locked in contract. Now, dust accruing in handlers is limited to the precision loss of the rate