### PR TITLE
M-11 (OZ Audit)

### DIFF
--- a/src/flash/handlers/base/UniswapFlashswapHandler.sol
+++ b/src/flash/handlers/base/UniswapFlashswapHandler.sol
@@ -168,10 +168,7 @@ abstract contract UniswapFlashswapHandler is IonHandlerBase, IUniswapV3SwapCallb
             : (uint256(amount1Delta), uint256(-amount0Delta));
 
         // it's technically possible to not receive the full output amount,
-        // so if no price limit has been specified, require this possibility away
-        if (sqrtPriceLimitX96 == 0 && amountOutReceived != amountOut) {
-            revert OutputAmountNotReceived(amountOutReceived, amountOut);
-        }
+        if (amountOutReceived != amountOut) revert OutputAmountNotReceived(amountOutReceived, amountOut);
     }
 
     /**


### PR DESCRIPTION
Since it is always desirable to get the exact amount out in `UniswapFlashswapHandler`, have output amount be validated even if `sqrtPriceLimitX96` is provided.