### PR TITLE
H-05, M-05, N-21 (OZ Audit)

### DIFF
--- a/src/oracles/spot/EthXSpotOracle.sol
+++ b/src/oracles/spot/EthXSpotOracle.sol
@@ -7,7 +7,10 @@ import { IChainlink } from "src/interfaces/IChainlink.sol";
 import { WadRayMath } from "src/libraries/math/WadRayMath.sol";
 
 interface IRedstonePriceFeed {
-    function latestAnswer() external view returns (int256 answer);
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
 }
 
 uint8 constant REDSTONE_DECIMALS = 8;
@@ -31,15 +34,16 @@ contract EthXSpotOracle is SpotOracle {
         USD_PER_ETH_CHAINLINK = IChainlink(_usdPerEthChainlink);
     }
 
-    // @notice Gets the price of ETHx in ETH. 
+    // @notice Gets the price of ETHx in ETH.
     // @dev redstone oracle returns dollar value per ETHx with 6 decimals.
     // This needs to be converted to [wad] and to ETH denomination.
-    // @return ethPerEthX price of ETHx in ETH [wad] 
+    // @return ethPerEthX price of ETHx in ETH [wad]
     function getPrice() public view override returns (uint256 ethPerEthX) {
         // get price from the protocol feed
         // usd per ETHx
+        (, int256 answer,,,) = REDSTONE_ETHX_PRICE_FEED.latestRoundData();
 
-        uint256 usdPerEthX = uint256(REDSTONE_ETHX_PRICE_FEED.latestAnswer()).scaleUpToWad(REDSTONE_DECIMALS); //
+        uint256 usdPerEthX = uint256(answer).scaleUpToWad(REDSTONE_DECIMALS); //
 
         // usd per ETH
         (, int256 _usdPerEth,,,) = USD_PER_ETH_CHAINLINK.latestRoundData(); // price of stETH denominated in ETH

--- a/test/fork/concrete/EthXReserveOracleFork.t.sol
+++ b/test/fork/concrete/EthXReserveOracleFork.t.sol
@@ -5,12 +5,32 @@ import { EthXReserveOracle } from "src/oracles/reserve/EthXReserveOracle.sol";
 import { ReserveFeed } from "src/oracles/reserve/ReserveFeed.sol";
 import { IStaderStakePoolsManager } from "src/interfaces/ProviderInterfaces.sol";
 import { WadRayMath, RAY } from "src/libraries/math/WadRayMath.sol";
+import { ReserveOracle } from "../../../src/oracles/reserve/ReserveOracle.sol";
+
 import { ReserveOracleSharedSetup } from "test/helpers/ReserveOracleSharedSetup.sol";
 
 contract EthXReserveOracleForkTest is ReserveOracleSharedSetup {
     using WadRayMath for *;
 
     // --- ETHx Reserve Oracle Test ---
+
+    function test_RevertWhen_UpdateIsOnCooldown() public {
+        uint256 maxChange = 3e25; // 0.03 3%
+        address[] memory feeds = new address[](3);
+        uint8 quorum = 0;
+        EthXReserveOracle ethXReserveOracle = new EthXReserveOracle(
+            STADER_STAKE_POOLS_MANAGER,
+            ETHX_ILK_INDEX,
+            feeds,
+            quorum,
+            maxChange
+        );
+
+        ethXReserveOracle.updateExchangeRate();
+
+        vm.expectRevert(abi.encodeWithSelector(ReserveOracle.UpdateCooldown.selector, block.timestamp));
+        ethXReserveOracle.updateExchangeRate();
+    }
 
     function test_EthXReserveOracleGetProtocolExchangeRate() public {
         uint256 maxChange = 3e25; // 0.03 3%

--- a/test/fork/concrete/SwEthReserveOracleFork.t.sol
+++ b/test/fork/concrete/SwEthReserveOracleFork.t.sol
@@ -5,10 +5,30 @@ import { SwEthReserveOracle } from "src/oracles/reserve/SwEthReserveOracle.sol";
 import { ReserveFeed } from "src/oracles/reserve/ReserveFeed.sol";
 import { ISwEth } from "src/interfaces/ProviderInterfaces.sol";
 import { RAY } from "src/libraries/math/WadRayMath.sol";
+import { ReserveOracle } from "../../../src/oracles/reserve/ReserveOracle.sol";
+
 import { ReserveOracleSharedSetup } from "test/helpers/ReserveOracleSharedSetup.sol";
 
 contract SwEthReserveOracleForkTest is ReserveOracleSharedSetup {
     // --- swETH Reserve Oracle Test ---
+
+    function test_RevertWhen_UpdateIsOnCooldown() public {
+        uint256 maxChange = 3e25; // 0.03 3%
+        address[] memory feeds = new address[](3);
+        uint8 quorum = 0;
+        SwEthReserveOracle swEthReserveOracle = new SwEthReserveOracle(
+            SWETH,
+            SWETH_ILK_INDEX, 
+            feeds, 
+            quorum,
+            maxChange
+        );
+
+        swEthReserveOracle.updateExchangeRate();
+
+        vm.expectRevert(abi.encodeWithSelector(ReserveOracle.UpdateCooldown.selector, block.timestamp));
+        swEthReserveOracle.updateExchangeRate();
+    }
 
     function test_SwEthReserveOracleGetProtocolExchangeRate() public {
         uint256 maxChange = 3e25; // 0.03 3%

--- a/test/fork/concrete/WstEthReserveOracleFork.t.sol
+++ b/test/fork/concrete/WstEthReserveOracleFork.t.sol
@@ -13,6 +13,19 @@ import { ReserveOracleSharedSetup } from "test/helpers/ReserveOracleSharedSetup.
 contract WstEthReserveOracleForkTest is ReserveOracleSharedSetup {
     // --- stETH Reserve Oracle Test ---
 
+    function test_RevertWhen_UpdateIsOnCooldown() public {
+        uint256 maxChange = 3e25; // 0.03 3%
+        address[] memory feeds = new address[](3);
+        uint8 quorum = 0;
+        WstEthReserveOracle wstEthReserveOracle =
+            new WstEthReserveOracle(WSTETH, STETH_ILK_INDEX, feeds, quorum, maxChange);
+
+        wstEthReserveOracle.updateExchangeRate();
+
+        vm.expectRevert(abi.encodeWithSelector(ReserveOracle.UpdateCooldown.selector, block.timestamp));
+        wstEthReserveOracle.updateExchangeRate();
+    }
+
     function test_WstEthReserveOracleGetProtocolExchangeRate() public {
         uint256 maxChange = 3e25; // 0.03 3%
         address[] memory feeds = new address[](3);


### PR DESCRIPTION
- Remove use of deprecated `latestAnswer()` function and instead use `latestRoundData()`
- Add cooldown on reserve oracle exchange rate updates so that the bounding is effective