### PR TITLE
Refactor Handler tests to be inheritable. 

### DIFF
--- a/script/08_DeployInitialHandlers.s.sol
+++ b/script/08_DeployInitialHandlers.s.sol
@@ -44,6 +44,8 @@ IUniswapV3Factory constant FACTORY = IUniswapV3Factory(0x1F98431c8aD98523631AE4a
 IWETH9 constant weth = IWETH9(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
 
 IUniswapV3Pool constant WSTETH_WETH_POOL = IUniswapV3Pool(0x109830a1AAaD605BbF02a9dFA7B0B92EC2FB7dAa);
+IUniswapV3Pool constant ETHX_WETH_POOL = IUniswapV3Pool(0x1b9669b12959Ad51B01FaBcF01EaBDFADB82f578);
+
 uint24 constant WSTETH_WETH_POOL_FEE = 100;
 
 contract DeployInitialHandlersScript is BaseScript {
@@ -71,6 +73,7 @@ contract DeployInitialHandlersScript is BaseScript {
             MAINNET_STADER,
             whitelist,
             WSTETH_WETH_POOL,
+            ETHX_WETH_POOL,
             0x37b18b10ce5635a84834b26095a0ae5639dcb7520000000000000000000005cb
         );
         swEthHandler = new SwEthHandler(SWETH_ILK_INDEX, ionPool, swEthGemJoin, whitelist, SWETH_ETH_POOL);

--- a/script/10_DeployIonZapper.s.sol
+++ b/script/10_DeployIonZapper.s.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.21;
 
-import { IonPool } from "src/IonPool.sol";
-import { Whitelist } from "src/Whitelist.sol";
-import { GemJoin } from "src/join/GemJoin.sol";
-import { IWETH9 } from "src/interfaces/IWETH9.sol";
-import { IWstEth } from "src/interfaces/ProviderInterfaces.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IonPool } from "../src/IonPool.sol";
+import { Whitelist } from "../src/Whitelist.sol";
+import { GemJoin } from "../src/join/GemJoin.sol";
+import { IWETH9 } from "../src/interfaces/IWETH9.sol";
+import { IWstEth } from "../src/interfaces/ProviderInterfaces.sol";
+import { IonZapper } from "../src/periphery/IonZapper.sol";
+import { WadRayMath } from "../src/libraries/math/WadRayMath.sol";
 
 import { BaseScript } from "./Base.s.sol";
-import { console2 } from "forge-std/Script.sol";
-import { safeconsole as console } from "forge-std/safeconsole.sol";
-import { IonZapper } from "src/periphery/IonZapper.sol";
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
-import { WadRayMath } from "src/libraries/math/WadRayMath.sol";
+
 import { stdJson as StdJson } from "forge-std/StdJson.sol";
 
 contract DeployIonZapperScript is BaseScript {

--- a/script/__TestBasic.s.sol
+++ b/script/__TestBasic.s.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.21;
 
-import { IonPool } from "src/IonPool.sol";
-import { IonZapper } from "src/periphery/IonZapper.sol";
-import { IWETH9 } from "src/interfaces/IWETH9.sol";
-import { BaseScript } from "script/Base.s.sol";
+import { IonPool } from "../src/IonPool.sol";
+import { IonZapper } from "../src/periphery/IonZapper.sol";
+import { IWETH9 } from "../src/interfaces/IWETH9.sol";
+
+import { BaseScript } from "./Base.s.sol";
+
 import { console2 } from "forge-std/console2.sol";
 
 // TODO: consolidate constants

--- a/src/flash/handlers/EthXHandler.sol
+++ b/src/flash/handlers/EthXHandler.sol
@@ -3,12 +3,13 @@ pragma solidity 0.8.21;
 
 import { IonPool } from "../../IonPool.sol";
 import { GemJoin } from "../../join/GemJoin.sol";
-import { IonHandlerBase } from "../../flash/handlers/base/IonHandlerBase.sol";
 import { Whitelist } from "../../Whitelist.sol";
 import { StaderLibrary } from "../../libraries/StaderLibrary.sol";
 import { IStaderStakePoolsManager } from "../../interfaces/ProviderInterfaces.sol";
-import { UniswapFlashloanBalancerSwapHandler } from "../../flash/handlers/base/UniswapFlashloanBalancerSwapHandler.sol";
-import { BalancerFlashloanDirectMintHandler } from "../../flash/handlers/base/BalancerFlashloanDirectMintHandler.sol";
+import { IonHandlerBase } from "./base/IonHandlerBase.sol";
+import { UniswapFlashloanBalancerSwapHandler } from "./base/UniswapFlashloanBalancerSwapHandler.sol";
+import { BalancerFlashloanDirectMintHandler } from "./base/BalancerFlashloanDirectMintHandler.sol";
+import { UniswapFlashswapHandler } from "./base/UniswapFlashswapHandler.sol";
 
 import { IUniswapV3Pool } from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 
@@ -17,7 +18,11 @@ import { IUniswapV3Pool } from "@uniswap/v3-core/contracts/interfaces/IUniswapV3
  *
  * @custom:security-contact security@molecularlabs.io
  */
-contract EthXHandler is UniswapFlashloanBalancerSwapHandler, BalancerFlashloanDirectMintHandler {
+contract EthXHandler is
+    UniswapFlashloanBalancerSwapHandler,
+    UniswapFlashswapHandler,
+    BalancerFlashloanDirectMintHandler
+{
     using StaderLibrary for IStaderStakePoolsManager;
 
     // Stader deposit contract is separate from the ETHx lst contract
@@ -30,7 +35,8 @@ contract EthXHandler is UniswapFlashloanBalancerSwapHandler, BalancerFlashloanDi
      * @param _gemJoin `GemJoin` contract address associated with ETHx.
      * @param _staderDeposit Address for the Stader deposit contract.
      * @param _whitelist Address of the `Whitelist` contract.
-     * @param _wstEthUniswapPool Address of the wstETH/ETH Uniswap V3 pool.
+     * @param _wstEthUniswapPool Address of the WSTETH/ETH Uniswap V3 pool.
+     * @param _ethXUniswapPool Address of the ETHx/ETH Uniswap V3 pool.
      * @param _balancerPoolId Balancer pool ID for the ETHx/ETH pool.
      */
     constructor(
@@ -40,10 +46,12 @@ contract EthXHandler is UniswapFlashloanBalancerSwapHandler, BalancerFlashloanDi
         IStaderStakePoolsManager _staderDeposit,
         Whitelist _whitelist,
         IUniswapV3Pool _wstEthUniswapPool,
+        IUniswapV3Pool _ethXUniswapPool,
         bytes32 _balancerPoolId
     )
         UniswapFlashloanBalancerSwapHandler(_wstEthUniswapPool, _balancerPoolId)
         IonHandlerBase(_ilkIndex, _ionPool, _gemJoin, _whitelist)
+        UniswapFlashswapHandler(_ethXUniswapPool, false)
     {
         STADER_DEPOSIT = _staderDeposit;
     }

--- a/src/interfaces/IReserveFeed.sol
+++ b/src/interfaces/IReserveFeed.sol
@@ -6,7 +6,6 @@ pragma solidity 0.8.21;
  * @notice Interface for the reserve feeds for Ion Protocol.
  *
  */
-
 interface IReserveFeed {
     /**
      * @dev updates the total reserve of the validator backed asset

--- a/test/fork/concrete/EthXHandlerFork.t.sol
+++ b/test/fork/concrete/EthXHandlerFork.t.sol
@@ -14,7 +14,10 @@ import { StaderLibrary } from "../../../src/libraries/StaderLibrary.sol";
 import { Whitelist } from "../../../src/Whitelist.sol";
 import { IonHandlerBase } from "../../../src/flash/handlers/base/IonHandlerBase.sol";
 
+import { BalancerFlashloanDirectMintHandler_Test } from "./handlers-base/BalancerFlashloanDirectMintHandler.t.sol";
+import { UniswapFlashloanBalancerSwapHandler_Test } from "./handlers-base/UniswapFlashloanBalancerSwapHandler.t.sol";
 import { IonHandler_ForkBase } from "../../helpers/IonHandlerForkBase.sol";
+import { IProviderLibraryExposed } from "../../helpers/IProviderLibraryExposed.sol";
 
 import { IFlashLoanRecipient } from "@balancer-labs/v2-interfaces/contracts/vault/IFlashLoanRecipient.sol";
 import { IERC20 as IERC20Balancer } from "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
@@ -28,10 +31,26 @@ using WadRayMath for uint256;
 using WadRayMath for uint104;
 using StaderLibrary for IStaderStakePoolsManager;
 
+contract StaderLibraryExposed is IProviderLibraryExposed {
+    IStaderStakePoolsManager staderDeposit;
+
+    constructor(IStaderStakePoolsManager staderDeposit_) {
+        staderDeposit = staderDeposit_;
+    }
+
+    function getEthAmountInForLstAmountOut(uint256 lstAmount) external view returns (uint256) {
+        return staderDeposit.getEthAmountInForLstAmountOut(lstAmount);
+    }
+
+    function getLstAmountOutForEthAmountIn(uint256 ethAmount) external view returns (uint256) {
+        return staderDeposit.getLstAmountOutForEthAmountIn(ethAmount);
+    }
+}
+
 contract EthXHandler_ForkBase is IonHandler_ForkBase {
     uint8 internal constant ilkIndex = 1;
     EthXHandler ethXHandler;
-    bytes32[] borrowerWhitelistProof;
+    StaderLibraryExposed staderLibraryExposed;
 
     function setUp() public virtual override {
         // Since Balancer EthX pool has no liquidity, this needs to be pinned to
@@ -45,8 +64,11 @@ contract EthXHandler_ForkBase is IonHandler_ForkBase {
             MAINNET_STADER,
             Whitelist(whitelist),
             WSTETH_WETH_POOL,
+            ETHX_WETH_POOL,
             0x37b18b10ce5635a84834b26095a0ae5639dcb7520000000000000000000005cb
         );
+
+        staderLibraryExposed = new StaderLibraryExposed(MAINNET_STADER);
 
         IERC20(address(MAINNET_ETHX)).approve(address(ethXHandler), type(uint256).max);
 
@@ -58,300 +80,27 @@ contract EthXHandler_ForkBase is IonHandler_ForkBase {
         vm.deal(address(this), INITIAL_BORROWER_COLLATERAL_BALANCE);
         MAINNET_STADER.depositForLst(INITIAL_BORROWER_COLLATERAL_BALANCE);
     }
+
+    function _getIlkIndex() internal pure override returns (uint8) {
+        return ilkIndex;
+    }
+
+    function _getProviderLibrary() internal view override returns (IProviderLibraryExposed) {
+        return staderLibraryExposed;
+    }
+
+    function _getHandler() internal view override returns (address) {
+        return address(ethXHandler);
+    }
 }
 
-contract EthXHandler_ForkTest is EthXHandler_ForkBase {
-    function testFork_FlashloanCollateral() public virtual {
-        uint256 initialDeposit = 1e18; // in ethX
-        uint256 resultingCollateral = 5e18; // in ethX
-        uint256 resultingDebt = MAINNET_STADER.getEthAmountInForLstAmountOut(resultingCollateral - initialDeposit);
-
-        weth.approve(address(ethXHandler), type(uint256).max);
-        ionPool.addOperator(address(ethXHandler));
-
-        uint256 gasBefore = gasleft();
-        ethXHandler.flashLeverageCollateral(initialDeposit, resultingCollateral, resultingDebt, new bytes32[](0));
-        uint256 gasAfter = gasleft();
-        if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertGe(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), resultingDebt);
-        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(ethXHandler)), 0);
-        assertLe(weth.balanceOf(address(ethXHandler)), roundingError);
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-    }
-
-    function testFork_FlashloanWeth() external {
-        uint256 initialDeposit = 1e18; // in ethX
-        uint256 resultingCollateral = 5e18; // in ethX
-        uint256 resultingDebt = MAINNET_STADER.getEthAmountInForLstAmountOut(resultingCollateral - initialDeposit);
-
-        weth.approve(address(ethXHandler), type(uint256).max);
-        ionPool.addOperator(address(ethXHandler));
-
-        uint256 gasBefore = gasleft();
-        ethXHandler.flashLeverageWeth(initialDeposit, resultingCollateral, resultingDebt, new bytes32[](0));
-        uint256 gasAfter = gasleft();
-        if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertApproxEqAbs(
-            ionPool.normalizedDebt(ilkIndex, address(this)).rayMulDown(ionPool.rate(ilkIndex)),
-            resultingDebt,
-            roundingError
-        );
-        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(ethXHandler)), 0);
-        assertLe(weth.balanceOf(address(ethXHandler)), roundingError);
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-    }
-
-    function testFork_FlashswapLeverage() external {
-        uint256 initialDeposit = 1e18;
-        uint256 resultingCollateral = 5e18;
-        uint256 maxResultingDebt = 4.5e18; // In weth
-
-        weth.approve(address(ethXHandler), type(uint256).max);
-        ionPool.addOperator(address(ethXHandler));
-
-        vm.expectRevert(abi.encodeWithSelector(IonHandlerBase.TransactionDeadlineReached.selector, block.timestamp));
-        ethXHandler.flashLeverageWethAndSwap(
-            initialDeposit, resultingCollateral, maxResultingDebt, block.timestamp, borrowerWhitelistProof
-        );
-
-        uint256 gasBefore = gasleft();
-        ethXHandler.flashLeverageWethAndSwap(
-            initialDeposit, resultingCollateral, maxResultingDebt, block.timestamp + 1, new bytes32[](0)
-        );
-        uint256 gasAfter = gasleft();
-        if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(ethXHandler)), 0);
-        assertLe(weth.balanceOf(address(ethXHandler)), roundingError);
-        assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
-    }
-
-    function testFork_FlashswapDeleverage() external {
-        uint256 initialDeposit = 1e18;
-        uint256 resultingCollateral = 5e18;
-        uint256 maxResultingDebt = type(uint256).max;
-
-        weth.approve(address(ethXHandler), type(uint256).max);
-        ionPool.addOperator(address(ethXHandler));
-
-        vm.recordLogs();
-        ethXHandler.flashLeverageWethAndSwap(
-            initialDeposit, resultingCollateral, maxResultingDebt, block.timestamp + 1, new bytes32[](0)
-        );
-
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-
-        uint256 normalizedDebtCreated;
-        for (uint256 i = 0; i < entries.length; i++) {
-            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
-            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
-            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
-        }
-
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-        assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), normalizedDebtCreated);
-
-        vm.warp(block.timestamp + 3 hours);
-
-        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
-        // Want to completely deleverage position and only leave initial capital
-        // in vault
-        uint256 maxCollateralToRemove = (resultingCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
-        // Remove all debt
-        uint256 normalizedDebtToRemove = ionPool.normalizedDebt(ilkIndex, address(this));
-
-        // Round up otherwise can leave 1 wei of dust in debt left
-        uint256 debtToRemove = normalizedDebtToRemove.rayMulUp(ionPool.rate(ilkIndex));
-
-        vm.expectRevert(abi.encodeWithSelector(IonHandlerBase.TransactionDeadlineReached.selector, block.timestamp));
-        ethXHandler.flashDeleverageWethAndSwap(maxCollateralToRemove, debtToRemove, block.timestamp);
-
-        uint256 gasBefore = gasleft();
-        ethXHandler.flashDeleverageWethAndSwap(maxCollateralToRemove, debtToRemove, block.timestamp + 1);
-        uint256 gasAfter = gasleft();
-        if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertGe(ionPool.collateral(ilkIndex, address(this)), resultingCollateral - maxCollateralToRemove);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), 0);
-        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(ethXHandler)), 0);
-        assertLe(weth.balanceOf(address(ethXHandler)), roundingError);
-    }
-
-    function testFork_FlashswapDeleverageFull() external {
-        uint256 initialDeposit = 1e18;
-        uint256 resultingCollateral = 5e18;
-        uint256 maxResultingDebt = type(uint256).max;
-
-        weth.approve(address(ethXHandler), type(uint256).max);
-        ionPool.addOperator(address(ethXHandler));
-
-        vm.recordLogs();
-        ethXHandler.flashLeverageWethAndSwap(
-            initialDeposit, resultingCollateral, maxResultingDebt, block.timestamp + 1, new bytes32[](0)
-        );
-
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-
-        uint256 normalizedDebtCreated;
-        for (uint256 i = 0; i < entries.length; i++) {
-            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
-            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
-            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
-        }
-
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-        assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), normalizedDebtCreated);
-
-        vm.warp(block.timestamp + 3 hours);
-
-        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
-        // Want to completely deleverage position and only leave initial capital
-        // in vault
-        uint256 maxCollateralToRemove = (resultingCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
-
-        // Remove all debt
-        uint256 debtToRemove = type(uint256).max;
-        vm.expectRevert(abi.encodeWithSelector(IonHandlerBase.TransactionDeadlineReached.selector, block.timestamp));
-        ethXHandler.flashDeleverageWethAndSwap(maxCollateralToRemove, debtToRemove, block.timestamp);
-
-        uint256 gasBefore = gasleft();
-        ethXHandler.flashDeleverageWethAndSwap(maxCollateralToRemove, debtToRemove, block.timestamp + 1);
-        uint256 gasAfter = gasleft();
-        if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertGe(ionPool.collateral(ilkIndex, address(this)), resultingCollateral - maxCollateralToRemove);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), 0);
-        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(ethXHandler)), 0);
-        assertLe(weth.balanceOf(address(ethXHandler)), roundingError);
-    }
-
-    function testFork_RevertWhen_BalancerFlashloanNotInitiatedByHandler() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        IERC20Balancer[] memory addresses = new IERC20Balancer[](1);
-        addresses[0] = IERC20Balancer(address(MAINNET_ETHX));
-
-        uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 8e18;
-
-        vm.expectRevert(BalancerFlashloanDirectMintHandler.ExternalBalancerFlashloanNotAllowed.selector);
-        VAULT.flashLoan(IFlashLoanRecipient(address(ethXHandler)), addresses, amounts, abi.encode(msg.sender, 0, 0, 0));
-    }
-
-    function testFork_RevertWhen_FlashloanedMoreThanOneToken() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        IERC20Balancer[] memory addresses = new IERC20Balancer[](2);
-        addresses[0] = IERC20Balancer(address(MAINNET_ETHX));
-        addresses[1] = IERC20Balancer(address(weth));
-
-        uint256[] memory amounts = new uint256[](2);
-        amounts[0] = 8e18;
-        amounts[1] = 8e18;
-
-        vm.expectRevert(abi.encodeWithSelector(BalancerFlashloanDirectMintHandler.FlashLoanedTooManyTokens.selector, 2));
-        VAULT.flashLoan(IFlashLoanRecipient(address(ethXHandler)), addresses, amounts, abi.encode(msg.sender, 0, 0, 0));
-    }
-
-    function testFork_RevertWhen_UntrustedCallerCallsFlashloanCallback() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        IERC20Balancer[] memory addresses = new IERC20Balancer[](1);
-        addresses[0] = IERC20Balancer(address(MAINNET_ETHX));
-
-        uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 8e18;
-
-        vm.expectRevert(
-            abi.encodeWithSelector(BalancerFlashloanDirectMintHandler.ReceiveCallerNotVault.selector, address(this))
-        );
-        ethXHandler.receiveFlashLoan(addresses, amounts, amounts, "");
-    }
-
-    function testFork_RevertWhen_FlashloanedTokenIsNeitherWethNorCorrectLst() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        IERC20Balancer[] memory addresses = new IERC20Balancer[](1);
-        addresses[0] = IERC20Balancer(address(MAINNET_ETHX));
-
-        uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 8e18;
-
-        // Should actually be impossible
-        vm.expectRevert(BalancerFlashloanDirectMintHandler.ExternalBalancerFlashloanNotAllowed.selector);
-        vm.prank(address(VAULT));
-        ethXHandler.receiveFlashLoan(addresses, amounts, amounts, abi.encode(address(this), 100e18, 100e18, 100e18));
-    }
-
-    function testFork_RevertWhen_UntrustedCallerCallsUniswapFlashloanCallback() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(UniswapFlashloanBalancerSwapHandler.ReceiveCallerNotPool.selector, address(this))
-        );
-        ethXHandler.uniswapV3FlashCallback(1, 1, "");
-    }
-
-    function testFork_RevertWhen_FlashswapLeverageCreatesMoreDebtThanUserIsWilling() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        uint256 initialDeposit = 1e18;
-        uint256 resultingCollateral = 5e18;
-        uint256 maxResultingDebt = 3e18; // In weth
-
-        weth.approve(address(ethXHandler), type(uint256).max);
-        ionPool.addOperator(address(ethXHandler));
-
-        vm.expectRevert();
-        ethXHandler.flashLeverageWethAndSwap(
-            initialDeposit, resultingCollateral, maxResultingDebt, block.timestamp + 1, new bytes32[](0)
-        );
-    }
-
-    function testFork_RevertWhen_FlashswapDeleverageSellsMoreCollateralThanUserIsWilling() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        uint256 initialDeposit = 1e18;
-        uint256 resultingCollateral = 5e18;
-        uint256 maxResultingDebt = type(uint256).max;
-
-        weth.approve(address(ethXHandler), type(uint256).max);
-        ionPool.addOperator(address(ethXHandler));
-
-        ethXHandler.flashLeverageWethAndSwap(
-            initialDeposit, resultingCollateral, maxResultingDebt, block.timestamp + 1, new bytes32[](0)
-        );
-
-        // No slippage tolerance
-        uint256 slippageAndFeeTolerance = 1.0e18; // 0%
-        uint256 maxCollateralToRemove = (resultingCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
-        uint256 normalizedDebtToRemove = ionPool.normalizedDebt(ilkIndex, address(this));
-
-        // Round up otherwise can leave 1 wei of dust in debt left
-        uint256 debtToRemove = normalizedDebtToRemove.rayMulUp(ionPool.rate(ilkIndex));
-
-        vm.expectRevert();
-        ethXHandler.flashDeleverageWethAndSwap(maxCollateralToRemove, debtToRemove, block.timestamp + 1);
+contract EthXHandler_ForkTest is
+    EthXHandler_ForkBase,
+    BalancerFlashloanDirectMintHandler_Test,
+    UniswapFlashloanBalancerSwapHandler_Test
+{
+    function setUp() public virtual override(EthXHandler_ForkBase, IonHandler_ForkBase) {
+        super.setUp();
     }
 }
 
@@ -377,6 +126,7 @@ contract EthXHandlerWhitelist_ForkTest is EthXHandler_ForkTest {
         borrowerRoots[0] = borrowerWhitelistRoot;
 
         _whitelist = new Whitelist(borrowerRoots, bytes32(0));
+        _whitelist.updateBorrowersRoot(ilkIndex, borrowerWhitelistRoot);
         _whitelist.approveProtocolWhitelist(address(ethXHandler));
 
         ionPool.updateWhitelist(_whitelist);

--- a/test/fork/concrete/EthXHandlerFork.t.sol
+++ b/test/fork/concrete/EthXHandlerFork.t.sol
@@ -3,32 +3,16 @@ pragma solidity 0.8.21;
 
 import { IStaderStakePoolsManager } from "../../../src/interfaces/ProviderInterfaces.sol";
 import { EthXHandler } from "../../../src/flash/handlers/EthXHandler.sol";
-import { WadRayMath, WAD, RAY } from "../../../src/libraries/math/WadRayMath.sol";
-import {
-    BalancerFlashloanDirectMintHandler,
-    VAULT
-} from "../../../src/flash/handlers/base/BalancerFlashloanDirectMintHandler.sol";
-import { UniswapFlashloanBalancerSwapHandler } from
-    "../../../src/flash/handlers/base/UniswapFlashloanBalancerSwapHandler.sol";
 import { StaderLibrary } from "../../../src/libraries/StaderLibrary.sol";
 import { Whitelist } from "../../../src/Whitelist.sol";
-import { IonHandlerBase } from "../../../src/flash/handlers/base/IonHandlerBase.sol";
 
 import { BalancerFlashloanDirectMintHandler_Test } from "./handlers-base/BalancerFlashloanDirectMintHandler.t.sol";
 import { UniswapFlashloanBalancerSwapHandler_Test } from "./handlers-base/UniswapFlashloanBalancerSwapHandler.t.sol";
 import { IonHandler_ForkBase } from "../../helpers/IonHandlerForkBase.sol";
 import { IProviderLibraryExposed } from "../../helpers/IProviderLibraryExposed.sol";
 
-import { IFlashLoanRecipient } from "@balancer-labs/v2-interfaces/contracts/vault/IFlashLoanRecipient.sol";
-import { IERC20 as IERC20Balancer } from "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
-
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 
-import { Vm } from "forge-std/Vm.sol";
-import { console2 } from "forge-std/console2.sol";
-
-using WadRayMath for uint256;
-using WadRayMath for uint104;
 using StaderLibrary for IStaderStakePoolsManager;
 
 contract StaderLibraryExposed is IProviderLibraryExposed {

--- a/test/fork/concrete/IonZapper.t.sol
+++ b/test/fork/concrete/IonZapper.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
-import { IonPool } from "../../../src/IonPool.sol";
 import { IonZapper } from "../../../src/periphery/IonZapper.sol";
 import { Whitelist } from "../../../src/Whitelist.sol";
 import { IWETH9 } from "../../../src/interfaces/IWETH9.sol";
@@ -13,8 +12,6 @@ import { IonPoolSharedSetup } from "../../helpers/IonPoolSharedSetup.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
-
-import { safeconsole as console } from "forge-std/safeconsole.sol";
 
 contract IonZapper_ForkTest is IonPoolSharedSetup {
     using LidoLibrary for IWstEth;

--- a/test/fork/concrete/SpotOracle.t.sol
+++ b/test/fork/concrete/SpotOracle.t.sol
@@ -14,8 +14,6 @@ import { WadRayMath } from "../../../src/libraries/math/WadRayMath.sol";
 
 import { ReserveOracleSharedSetup } from "../../helpers/ReserveOracleSharedSetup.sol";
 
-import { console2 } from "forge-std/console2.sol";
-
 // fork tests for integrating with external contracts
 contract SpotOracleForkTest is ReserveOracleSharedSetup {
     using WadRayMath for uint256;

--- a/test/fork/concrete/SwEthHandlerFork.t.sol
+++ b/test/fork/concrete/SwEthHandlerFork.t.sol
@@ -3,32 +3,17 @@ pragma solidity 0.8.21;
 
 import { ISwEth } from "../../../src/interfaces/ProviderInterfaces.sol";
 import { SwEthHandler } from "../../../src/flash/handlers/SwEthHandler.sol";
-import { WadRayMath, WAD, RAY } from "../../../src/libraries/math/WadRayMath.sol";
-import {
-    BalancerFlashloanDirectMintHandler,
-    VAULT
-} from "../../../src/flash/handlers/base/BalancerFlashloanDirectMintHandler.sol";
-import { UniswapFlashswapHandler } from "../../../src/flash/handlers/base/UniswapFlashswapHandler.sol";
 import { SwellLibrary } from "../../../src/libraries/SwellLibrary.sol";
 import { Whitelist } from "../../../src/Whitelist.sol";
-import { IonHandlerBase } from "../../../src/flash/handlers/base/IonHandlerBase.sol";
 
 import { IonHandler_ForkBase } from "../../helpers/IonHandlerForkBase.sol";
 import { IProviderLibraryExposed } from "../../helpers/IProviderLibraryExposed.sol";
 import { BalancerFlashloanDirectMintHandler_Test } from "./handlers-base/BalancerFlashloanDirectMintHandler.t.sol";
 import { UniswapFlashswapHandler_Test } from "./handlers-base/UniswapFlashswapHandler.t.sol";
 
-import { IFlashLoanRecipient } from "@balancer-labs/v2-interfaces/contracts/vault/IFlashLoanRecipient.sol";
-import { IERC20 as IERC20Balancer } from "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
-
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 
-import { Vm } from "forge-std/Vm.sol";
-import { console2 } from "forge-std/console2.sol";
-
-using WadRayMath for uint256;
-using WadRayMath for uint104;
 using SwellLibrary for ISwEth;
 
 contract SwellLibraryExposed is IProviderLibraryExposed {

--- a/test/fork/concrete/SwEthHandlerFork.t.sol
+++ b/test/fork/concrete/SwEthHandlerFork.t.sol
@@ -14,6 +14,9 @@ import { Whitelist } from "../../../src/Whitelist.sol";
 import { IonHandlerBase } from "../../../src/flash/handlers/base/IonHandlerBase.sol";
 
 import { IonHandler_ForkBase } from "../../helpers/IonHandlerForkBase.sol";
+import { IProviderLibraryExposed } from "../../helpers/IProviderLibraryExposed.sol";
+import { BalancerFlashloanDirectMintHandler_Test } from "./handlers-base/BalancerFlashloanDirectMintHandler.t.sol";
+import { UniswapFlashswapHandler_Test } from "./handlers-base/UniswapFlashswapHandler.t.sol";
 
 import { IFlashLoanRecipient } from "@balancer-labs/v2-interfaces/contracts/vault/IFlashLoanRecipient.sol";
 import { IERC20 as IERC20Balancer } from "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
@@ -28,11 +31,26 @@ using WadRayMath for uint256;
 using WadRayMath for uint104;
 using SwellLibrary for ISwEth;
 
+contract SwellLibraryExposed is IProviderLibraryExposed {
+    ISwEth swEth;
+
+    constructor(ISwEth swEth_) {
+        swEth = swEth_;
+    }
+
+    function getEthAmountInForLstAmountOut(uint256 lstAmount) external view returns (uint256) {
+        return swEth.getEthAmountInForLstAmountOut(lstAmount);
+    }
+
+    function getLstAmountOutForEthAmountIn(uint256 ethAmount) external view returns (uint256) {
+        return swEth.getLstAmountOutForEthAmountIn(ethAmount);
+    }
+}
+
 contract SwEthHandler_ForkBase is IonHandler_ForkBase {
     uint8 internal constant ilkIndex = 2;
     SwEthHandler swEthHandler;
-    uint160 sqrtPriceLimitX96;
-    bytes32[] borrowerWhitelistProof;
+    SwellLibraryExposed providerLibrary;
 
     function setUp() public virtual override {
         super.setUp();
@@ -45,338 +63,37 @@ contract SwEthHandler_ForkBase is IonHandler_ForkBase {
             ionPool.updateIlkDebtCeiling(i, type(uint256).max);
         }
 
+        providerLibrary = new SwellLibraryExposed(MAINNET_SWELL);
+
         vm.deal(address(this), INITIAL_BORROWER_COLLATERAL_BALANCE);
         MAINNET_SWELL.depositForLst(INITIAL_BORROWER_COLLATERAL_BALANCE);
+    }
+
+    function _getIlkIndex() internal pure override returns (uint8) {
+        return ilkIndex;
+    }
+
+    function _getProviderLibrary() internal view override returns (IProviderLibraryExposed) {
+        return providerLibrary;
+    }
+
+    function _getHandler() internal view override returns (address) {
+        return address(swEthHandler);
+    }
+}
+
+contract SwEthHandler_ForkTest is
+    SwEthHandler_ForkBase,
+    BalancerFlashloanDirectMintHandler_Test,
+    UniswapFlashswapHandler_Test
+{
+    function setUp() public virtual override(IonHandler_ForkBase, SwEthHandler_ForkBase) {
+        super.setUp();
 
         // If price of the pool ends up being larger than the exchange rate,
         // then a direct 1:1 contract mint is more favorable
         uint256 exchangeRate = MAINNET_SWELL.ethToSwETHRate();
         sqrtPriceLimitX96 = uint160(Math.sqrt(uint256(exchangeRate << 192) / 1e18));
-    }
-}
-
-contract SwEthHandler_ForkTest is SwEthHandler_ForkBase {
-    function testFork_FlashloanCollateral() public virtual {
-        uint256 initialDeposit = 1e18; // in swEth
-        uint256 resultingCollateral = 5e18; // in swEth
-        uint256 resultingDebt = MAINNET_SWELL.getEthAmountInForLstAmountOut(resultingCollateral - initialDeposit);
-
-        weth.approve(address(swEthHandler), type(uint256).max);
-        ionPool.addOperator(address(swEthHandler));
-
-        uint256 gasBefore = gasleft();
-        swEthHandler.flashLeverageCollateral(initialDeposit, resultingCollateral, resultingDebt, new bytes32[](0));
-        uint256 gasAfter = gasleft();
-        if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertGe(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), resultingDebt);
-        assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(swEthHandler)), 0);
-        assertLe(weth.balanceOf(address(swEthHandler)), roundingError);
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-    }
-
-    function testFork_FlashloanWeth() external {
-        uint256 initialDeposit = 1e18; // in swEth
-        uint256 resultingCollateral = 5e18; // in swEth
-        uint256 resultingDebt = MAINNET_SWELL.getEthAmountInForLstAmountOut(resultingCollateral - initialDeposit);
-
-        weth.approve(address(swEthHandler), type(uint256).max);
-        ionPool.addOperator(address(swEthHandler));
-
-        uint256 gasBefore = gasleft();
-        swEthHandler.flashLeverageWeth(initialDeposit, resultingCollateral, resultingDebt, new bytes32[](0));
-        uint256 gasAfter = gasleft();
-        if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertApproxEqAbs(
-            ionPool.normalizedDebt(ilkIndex, address(this)).rayMulDown(ionPool.rate(ilkIndex)),
-            resultingDebt,
-            roundingError
-        );
-        assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(swEthHandler)), 0);
-        assertLe(weth.balanceOf(address(swEthHandler)), roundingError);
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-    }
-
-    function testFork_FlashswapLeverage() external {
-        uint256 initialDeposit = 1e18;
-        uint256 resultingCollateral = 5e18;
-        uint256 maxResultingDebt = 4.5e18; // In weth
-
-        weth.approve(address(swEthHandler), type(uint256).max);
-        ionPool.addOperator(address(swEthHandler));
-
-        vm.expectRevert(abi.encodeWithSelector(IonHandlerBase.TransactionDeadlineReached.selector, block.timestamp));
-        swEthHandler.flashswapLeverage(
-            initialDeposit,
-            resultingCollateral,
-            maxResultingDebt,
-            sqrtPriceLimitX96,
-            block.timestamp,
-            borrowerWhitelistProof
-        );
-
-        uint256 gasBefore = gasleft();
-        swEthHandler.flashswapLeverage(
-            initialDeposit,
-            resultingCollateral,
-            maxResultingDebt,
-            sqrtPriceLimitX96,
-            block.timestamp + 1,
-            new bytes32[](0)
-        );
-        uint256 gasAfter = gasleft();
-        if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-        assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(swEthHandler)), 0);
-        assertLe(weth.balanceOf(address(swEthHandler)), roundingError);
-        assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
-    }
-
-    function testFork_FlashswapDeleverage() external {
-        uint256 initialDeposit = 1e18;
-        uint256 resultingCollateral = 5e18;
-        uint256 maxResultingDebt = type(uint256).max;
-
-        weth.approve(address(swEthHandler), type(uint256).max);
-        ionPool.addOperator(address(swEthHandler));
-
-        vm.recordLogs();
-        swEthHandler.flashswapLeverage(
-            initialDeposit,
-            resultingCollateral,
-            maxResultingDebt,
-            sqrtPriceLimitX96,
-            block.timestamp + 1,
-            new bytes32[](0)
-        );
-
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-
-        uint256 normalizedDebtCreated;
-        for (uint256 i = 0; i < entries.length; i++) {
-            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
-            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
-            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
-        }
-
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-        assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), normalizedDebtCreated);
-
-        vm.warp(block.timestamp + 3 hours);
-
-        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
-        // Want to completely deleverage position and only leave initial capital
-        // in vault
-        uint256 maxCollateralToRemove = (resultingCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
-        // Remove all debt
-        uint256 normalizedDebtToRemove = ionPool.normalizedDebt(ilkIndex, address(this));
-
-        // Round up otherwise can leave 1 wei of dust in debt left
-        uint256 debtToRemove = normalizedDebtToRemove.rayMulUp(ionPool.rate(ilkIndex));
-
-        vm.expectRevert(abi.encodeWithSelector(IonHandlerBase.TransactionDeadlineReached.selector, block.timestamp));
-        swEthHandler.flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0, block.timestamp);
-
-        swEthHandler.flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0, block.timestamp + 1);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertGe(ionPool.collateral(ilkIndex, address(this)), resultingCollateral - maxCollateralToRemove);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), 0);
-        assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(swEthHandler)), 0);
-        assertLe(weth.balanceOf(address(swEthHandler)), roundingError);
-    }
-
-    function testFork_FlashswapDeleverageFull() external {
-        uint256 initialDeposit = 1e18;
-        uint256 resultingCollateral = 5e18;
-        uint256 maxResultingDebt = type(uint256).max;
-
-        weth.approve(address(swEthHandler), type(uint256).max);
-        ionPool.addOperator(address(swEthHandler));
-
-        vm.recordLogs();
-        swEthHandler.flashswapLeverage(
-            initialDeposit,
-            resultingCollateral,
-            maxResultingDebt,
-            sqrtPriceLimitX96,
-            block.timestamp + 1,
-            new bytes32[](0)
-        );
-
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-
-        uint256 normalizedDebtCreated;
-        for (uint256 i = 0; i < entries.length; i++) {
-            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
-            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
-            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
-        }
-
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-        assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), normalizedDebtCreated);
-
-        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
-        // Want to completely deleverage position and only leave initial capital
-        // in vault
-        uint256 maxCollateralToRemove = (resultingCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
-
-        // Remove all debt
-        uint256 debtToRemove = type(uint256).max;
-
-        swEthHandler.flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0, block.timestamp + 1);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertGe(ionPool.collateral(ilkIndex, address(this)), resultingCollateral - maxCollateralToRemove);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), 0);
-        assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(swEthHandler)), 0);
-        assertLe(weth.balanceOf(address(swEthHandler)), roundingError);
-    }
-
-    function testFork_RevertWhen_FlashloanNotInitiatedByHandler() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        IERC20Balancer[] memory addresses = new IERC20Balancer[](1);
-        addresses[0] = IERC20Balancer(address(MAINNET_SWELL));
-
-        uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 8e18;
-
-        vm.expectRevert(BalancerFlashloanDirectMintHandler.ExternalBalancerFlashloanNotAllowed.selector);
-        VAULT.flashLoan(IFlashLoanRecipient(address(swEthHandler)), addresses, amounts, abi.encode(msg.sender, 0, 0, 0));
-    }
-
-    function testFork_RevertWhen_FlashloanedMoreThanOneToken() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        IERC20Balancer[] memory addresses = new IERC20Balancer[](2);
-        addresses[0] = IERC20Balancer(address(weth));
-        addresses[1] = IERC20Balancer(address(MAINNET_SWELL));
-
-        uint256[] memory amounts = new uint256[](2);
-        amounts[0] = 8e18;
-        amounts[1] = 8e18;
-
-        vm.expectRevert(abi.encodeWithSelector(BalancerFlashloanDirectMintHandler.FlashLoanedTooManyTokens.selector, 2));
-        VAULT.flashLoan(IFlashLoanRecipient(address(swEthHandler)), addresses, amounts, abi.encode(msg.sender, 0, 0, 0));
-    }
-
-    function testFork_RevertWhen_UntrustedCallerCallsFlashloanCallback() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        IERC20Balancer[] memory addresses = new IERC20Balancer[](1);
-        addresses[0] = IERC20Balancer(address(MAINNET_SWELL));
-
-        uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 8e18;
-
-        vm.expectRevert(
-            abi.encodeWithSelector(BalancerFlashloanDirectMintHandler.ReceiveCallerNotVault.selector, address(this))
-        );
-        swEthHandler.receiveFlashLoan(addresses, amounts, amounts, "");
-    }
-
-    function testFork_RevertWhen_FlashloanedTokenIsNeitherWethNorCorrectLst() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        IERC20Balancer[] memory addresses = new IERC20Balancer[](1);
-        addresses[0] = IERC20Balancer(address(MAINNET_ETHX));
-
-        uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 8e18;
-
-        // Should actually be impossible
-        vm.expectRevert(BalancerFlashloanDirectMintHandler.ExternalBalancerFlashloanNotAllowed.selector);
-        vm.prank(address(VAULT));
-        swEthHandler.receiveFlashLoan(addresses, amounts, amounts, abi.encode(address(this), 100e18, 100e18, 100e18));
-    }
-
-    function testFork_RevertWhen_UntrustedCallerCallsFlashswapCallback() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(UniswapFlashswapHandler.CallbackOnlyCallableByPool.selector, address(this))
-        );
-        swEthHandler.uniswapV3SwapCallback(1, 1, "");
-    }
-
-    function testFork_RevertWhen_TradingInZeroLiquidityRegion() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        vm.prank(address(SWETH_ETH_POOL));
-        vm.expectRevert(UniswapFlashswapHandler.InvalidZeroLiquidityRegionSwap.selector);
-        swEthHandler.uniswapV3SwapCallback(0, 0, "");
-    }
-
-    function testFork_RevertWhen_FlashswapLeverageCreatesMoreDebtThanUserIsWilling() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        uint256 initialDeposit = 1e18;
-        uint256 resultingCollateral = 5e18;
-        uint256 maxResultingDebt = 3e18; // In weth
-
-        weth.approve(address(swEthHandler), type(uint256).max);
-        ionPool.addOperator(address(swEthHandler));
-
-        vm.expectRevert();
-        swEthHandler.flashswapLeverage(
-            initialDeposit,
-            resultingCollateral,
-            maxResultingDebt,
-            sqrtPriceLimitX96,
-            block.timestamp + 1,
-            new bytes32[](0)
-        );
-    }
-
-    function testFork_RevertWhen_FlashswapDeleverageSellsMoreCollateralThanUserIsWilling() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        uint256 initialDeposit = 1e18;
-        uint256 resultingCollateral = 5e18;
-        uint256 maxResultingDebt = type(uint256).max;
-
-        weth.approve(address(swEthHandler), type(uint256).max);
-        ionPool.addOperator(address(swEthHandler));
-
-        swEthHandler.flashswapLeverage(
-            initialDeposit,
-            resultingCollateral,
-            maxResultingDebt,
-            sqrtPriceLimitX96,
-            block.timestamp + 1,
-            new bytes32[](0)
-        );
-
-        uint256 slippageAndFeeTolerance = 1.0e18; // 0%
-        // Want to completely deleverage position and only leave initial capital
-        // in vault
-        uint256 maxCollateralToRemove = (resultingCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
-        // Remove all debt
-        uint256 normalizedDebtToRemove = ionPool.normalizedDebt(ilkIndex, address(this));
-
-        // Round up otherwise can leave 1 wei of dust in debt left
-        uint256 debtToRemove = normalizedDebtToRemove.rayMulUp(ionPool.rate(ilkIndex));
-
-        vm.expectRevert();
-        swEthHandler.flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0, block.timestamp + 1);
     }
 }
 
@@ -402,6 +119,7 @@ contract SwEthHandlerWhitelist_ForkTest is SwEthHandler_ForkTest {
         borrowerRoots[0] = borrowerWhitelistRoot;
 
         _whitelist = new Whitelist(borrowerRoots, bytes32(0));
+        _whitelist.updateBorrowersRoot(ilkIndex, borrowerWhitelistRoot);
         _whitelist.approveProtocolWhitelist(address(swEthHandler));
 
         ionPool.updateWhitelist(_whitelist);

--- a/test/fork/concrete/WstEthHandlerFork.t.sol
+++ b/test/fork/concrete/WstEthHandlerFork.t.sol
@@ -13,7 +13,10 @@ import { LidoLibrary } from "../../../src/libraries/LidoLibrary.sol";
 import { Whitelist } from "../../../src/Whitelist.sol";
 import { IonHandlerBase } from "../../../src/flash/handlers/base/IonHandlerBase.sol";
 
+import { BalancerFlashloanDirectMintHandler_Test } from "./handlers-base/BalancerFlashloanDirectMintHandler.t.sol";
+import { UniswapFlashswapHandler_Test } from "./handlers-base/UniswapFlashswapHandler.t.sol";
 import { IonHandler_ForkBase } from "../../helpers/IonHandlerForkBase.sol";
+import { IProviderLibraryExposed } from "../../helpers/IProviderLibraryExposed.sol";
 
 import { IFlashLoanRecipient } from "@balancer-labs/v2-interfaces/contracts/vault/IFlashLoanRecipient.sol";
 import { IERC20 as IERC20Balancer } from "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
@@ -28,11 +31,26 @@ using WadRayMath for uint256;
 using WadRayMath for uint104;
 using LidoLibrary for IWstEth;
 
+contract LidoLibraryExposed is IProviderLibraryExposed {
+    IWstEth wstEth;
+
+    constructor(IWstEth wstEth_) {
+        wstEth = wstEth_;
+    }
+
+    function getEthAmountInForLstAmountOut(uint256 lstAmount) external view returns (uint256) {
+        return wstEth.getEthAmountInForLstAmountOut(lstAmount);
+    }
+
+    function getLstAmountOutForEthAmountIn(uint256 ethAmount) external view returns (uint256) {
+        return wstEth.getLstAmountOutForEthAmountIn(ethAmount);
+    }
+}
+
 contract WstEthHandler_ForkBase is IonHandler_ForkBase {
     uint8 internal constant ilkIndex = 0;
     WstEthHandler wstEthHandler;
-    uint160 sqrtPriceLimitX96;
-    bytes32[] borrowerWhitelistProof;
+    IProviderLibraryExposed providerLibrary;
 
     function setUp() public virtual override {
         super.setUp();
@@ -46,13 +64,10 @@ contract WstEthHandler_ForkBase is IonHandler_ForkBase {
             ionPool.updateIlkDebtCeiling(i, type(uint256).max);
         }
 
+        providerLibrary = new LidoLibraryExposed(MAINNET_WSTETH);
+
         vm.deal(address(this), INITIAL_BORROWER_COLLATERAL_BALANCE);
         MAINNET_WSTETH.depositForLst(INITIAL_BORROWER_COLLATERAL_BALANCE);
-
-        // If price of the pool ends up being larger than the exchange rate,
-        // then a direct 1:1 contract mint is more favorable
-        uint256 exchangeRate = MAINNET_WSTETH.getStETHByWstETH(1 ether);
-        sqrtPriceLimitX96 = uint160(Math.sqrt(uint256(exchangeRate << 192) / 1e18));
     }
 
     function _mintStEth(uint256 amount) internal returns (uint256) {
@@ -63,402 +78,32 @@ contract WstEthHandler_ForkBase is IonHandler_ForkBase {
         uint256 resultingBalance = IERC20(address(MAINNET_STETH)).balanceOf(address(this));
         return resultingBalance - beginningBalance;
     }
+
+    function _getIlkIndex() internal pure override returns (uint8) {
+        return ilkIndex;
+    }
+
+    function _getProviderLibrary() internal view override returns (IProviderLibraryExposed) {
+        return providerLibrary;
+    }
+
+    function _getHandler() internal view override returns (address) {
+        return address(wstEthHandler);
+    }
 }
 
-contract WstEthHandler_ForkTest is WstEthHandler_ForkBase {
-    function testFork_FlashloanCollateral() public virtual {
-        uint256 initialDeposit = 1e18; // in wstEth
-        uint256 resultingAdditionalCollateral = 5e18; // in wstEth
-        uint256 maxResultingDebt =
-            MAINNET_WSTETH.getEthAmountInForLstAmountOut(resultingAdditionalCollateral - initialDeposit);
-
-        weth.approve(address(wstEthHandler), type(uint256).max);
-        ionPool.addOperator(address(wstEthHandler));
-
-        if (Whitelist(whitelist).borrowersRoot(0) != 0) {
-            vm.expectRevert(abi.encodeWithSelector(Whitelist.NotWhitelistedBorrower.selector, 0, address(this)));
-            wstEthHandler.flashLeverageCollateral(
-                initialDeposit, resultingAdditionalCollateral, maxResultingDebt, new bytes32[](0)
-            );
-        }
-
-        uint256 gasBefore = gasleft();
-        wstEthHandler.flashLeverageCollateral(
-            initialDeposit, resultingAdditionalCollateral, maxResultingDebt, borrowerWhitelistProof
-        );
-        uint256 gasAfter = gasleft();
-        if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertGe(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
-        assertEq(IERC20(address(MAINNET_WSTETH)).balanceOf(address(wstEthHandler)), 0);
-        assertLe(weth.balanceOf(address(wstEthHandler)), roundingError);
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingAdditionalCollateral);
-    }
-
-    function testFork_FlashloanCollateralPositionRequiresZeroDebtButMaxAllowsMore() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        uint256 initialDeposit = 1e18; // in wstEth
-        uint256 resultingAdditionalCollateral = 1e18 + 1; // in wstEth
-        uint256 resultingDebt =
-            MAINNET_WSTETH.getEthAmountInForLstAmountOut(resultingAdditionalCollateral - initialDeposit);
-        uint256 maxResultingDebt = type(uint256).max;
-
-        weth.approve(address(wstEthHandler), type(uint256).max);
-        ionPool.addOperator(address(wstEthHandler));
-
-        if (Whitelist(whitelist).borrowersRoot(0) != 0) {
-            vm.expectRevert(abi.encodeWithSelector(Whitelist.NotWhitelistedBorrower.selector, 0, address(this)));
-            wstEthHandler.flashLeverageCollateral(
-                initialDeposit, resultingAdditionalCollateral, maxResultingDebt, new bytes32[](0)
-            );
-        }
-
-        uint256 gasBefore = gasleft();
-        wstEthHandler.flashLeverageCollateral(
-            initialDeposit, resultingAdditionalCollateral, maxResultingDebt, borrowerWhitelistProof
-        );
-        uint256 gasAfter = gasleft();
-        if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertGe(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), resultingDebt);
-        assertEq(IERC20(address(MAINNET_WSTETH)).balanceOf(address(wstEthHandler)), 0);
-        assertLe(weth.balanceOf(address(wstEthHandler)), roundingError);
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingAdditionalCollateral);
-    }
-
-    function testFork_FlashloanWeth() external {
-        uint256 initialDeposit = 1e18; // in wstEth
-        uint256 resultingAdditionalCollateral = 5e18; // in wstEth
-        uint256 maxResultingDebt =
-            MAINNET_WSTETH.getEthAmountInForLstAmountOut(resultingAdditionalCollateral - initialDeposit);
-
-        weth.approve(address(wstEthHandler), type(uint256).max);
-        ionPool.addOperator(address(wstEthHandler));
-
-        if (Whitelist(whitelist).borrowersRoot(0) != 0) {
-            vm.expectRevert(abi.encodeWithSelector(Whitelist.NotWhitelistedBorrower.selector, 0, address(this)));
-            wstEthHandler.flashLeverageWeth(
-                initialDeposit, resultingAdditionalCollateral, maxResultingDebt, new bytes32[](0)
-            );
-        }
-
-        uint256 gasBefore = gasleft();
-        wstEthHandler.flashLeverageWeth(
-            initialDeposit, resultingAdditionalCollateral, maxResultingDebt, borrowerWhitelistProof
-        );
-        uint256 gasAfter = gasleft();
-        if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertApproxEqAbs(
-            ionPool.normalizedDebt(ilkIndex, address(this)).rayMulDown(ionPool.rate(ilkIndex)),
-            maxResultingDebt,
-            roundingError
-        );
-        assertEq(IERC20(address(MAINNET_WSTETH)).balanceOf(address(wstEthHandler)), 0);
-        assertLe(weth.balanceOf(address(wstEthHandler)), roundingError);
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingAdditionalCollateral);
-    }
-
-    function testFork_FlashswapLeverage() external {
-        uint256 initialDeposit = 1e18;
-        uint256 resultingAdditionalCollateral = 5e18;
-        uint256 maxResultingDebt = 4.9e18; // In weth
-
-        weth.approve(address(wstEthHandler), type(uint256).max);
-        ionPool.addOperator(address(wstEthHandler));
-
-        if (Whitelist(whitelist).borrowersRoot(0) != 0) {
-            vm.expectRevert(abi.encodeWithSelector(Whitelist.NotWhitelistedBorrower.selector, 0, address(this)));
-            wstEthHandler.flashswapLeverage(
-                initialDeposit,
-                resultingAdditionalCollateral,
-                maxResultingDebt,
-                sqrtPriceLimitX96,
-                block.timestamp + 1,
-                new bytes32[](0)
-            );
-        }
-
-        vm.expectRevert(abi.encodeWithSelector(IonHandlerBase.TransactionDeadlineReached.selector, block.timestamp));
-        wstEthHandler.flashswapLeverage(
-            initialDeposit,
-            resultingAdditionalCollateral,
-            maxResultingDebt,
-            sqrtPriceLimitX96,
-            block.timestamp,
-            borrowerWhitelistProof
-        );
-
-        uint256 gasBefore = gasleft();
-        wstEthHandler.flashswapLeverage(
-            initialDeposit,
-            resultingAdditionalCollateral,
-            maxResultingDebt,
-            sqrtPriceLimitX96,
-            block.timestamp + 1,
-            borrowerWhitelistProof
-        );
-        uint256 gasAfter = gasleft();
-        if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingAdditionalCollateral);
-        assertEq(IERC20(address(MAINNET_WSTETH)).balanceOf(address(wstEthHandler)), 0);
-        assertLe(weth.balanceOf(address(wstEthHandler)), roundingError);
-        assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
-    }
-
-    function testFork_FlashswapDeleverage() external {
-        uint256 initialDeposit = 1e18;
-        uint256 resultingAdditionalCollateral = 5e18;
-        uint256 maxResultingDebt = type(uint256).max;
-
-        weth.approve(address(wstEthHandler), type(uint256).max);
-        ionPool.addOperator(address(wstEthHandler));
-
-        vm.recordLogs();
-        wstEthHandler.flashswapLeverage(
-            initialDeposit,
-            resultingAdditionalCollateral,
-            maxResultingDebt,
-            sqrtPriceLimitX96,
-            block.timestamp + 1,
-            borrowerWhitelistProof
-        );
-
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-
-        uint256 normalizedDebtCreated;
-        for (uint256 i = 0; i < entries.length; i++) {
-            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
-            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
-            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
-        }
-
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingAdditionalCollateral);
-        assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), normalizedDebtCreated);
-
-        vm.warp(block.timestamp + 3 hours);
-
-        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
-        // Want to completely deleverage position and only leave initial capital
-        // in vault
-        uint256 maxCollateralToRemove = (resultingAdditionalCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
-        // Remove all debt
-        uint256 normalizedDebtToRemove = ionPool.normalizedDebt(ilkIndex, address(this));
-
-        // Round up otherwise can leave 1 wei of dust in debt left
-        uint256 debtToRemove = normalizedDebtToRemove.rayMulUp(ionPool.rate(ilkIndex));
-
-        vm.expectRevert(abi.encodeWithSelector(IonHandlerBase.TransactionDeadlineReached.selector, block.timestamp));
-        wstEthHandler.flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0, block.timestamp);
-
-        wstEthHandler.flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0, block.timestamp + 1);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertGe(ionPool.collateral(ilkIndex, address(this)), resultingAdditionalCollateral - maxCollateralToRemove);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), 0);
-        assertEq(IERC20(address(MAINNET_WSTETH)).balanceOf(address(wstEthHandler)), 0);
-        assertLe(weth.balanceOf(address(wstEthHandler)), roundingError);
-    }
-
-    function testFork_FlashswapDeleverageFull() external {
-        uint256 initialDeposit = 1e18;
-        uint256 resultingAdditionalCollateral = 5e18;
-        uint256 maxResultingDebt = type(uint256).max;
-
-        weth.approve(address(wstEthHandler), type(uint256).max);
-        ionPool.addOperator(address(wstEthHandler));
-
-        vm.recordLogs();
-        wstEthHandler.flashswapLeverage(
-            initialDeposit,
-            resultingAdditionalCollateral,
-            maxResultingDebt,
-            sqrtPriceLimitX96,
-            block.timestamp + 1,
-            borrowerWhitelistProof
-        );
-
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-
-        uint256 normalizedDebtCreated;
-        for (uint256 i = 0; i < entries.length; i++) {
-            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
-            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
-            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
-        }
-
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingAdditionalCollateral);
-        assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), normalizedDebtCreated);
-
-        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
-        // Want to completely deleverage position and only leave initial capital
-        // in vault
-        uint256 maxCollateralToRemove = (resultingAdditionalCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
-        // Remove all debt
-
-        // Round up otherwise can leave 1 wei of dust in debt left
-        uint256 debtToRemove = type(uint256).max;
-
-        wstEthHandler.flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0, block.timestamp + 1);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertGe(ionPool.collateral(ilkIndex, address(this)), resultingAdditionalCollateral - maxCollateralToRemove);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), 0);
-        assertEq(IERC20(address(MAINNET_WSTETH)).balanceOf(address(wstEthHandler)), 0);
-        assertLe(weth.balanceOf(address(wstEthHandler)), roundingError);
-    }
-
-    function testFork_RevertWhen_FlashloanNotInitiatedByHandler() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        IERC20Balancer[] memory addresses = new IERC20Balancer[](1);
-        addresses[0] = IERC20Balancer(address(MAINNET_WSTETH));
-
-        uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 8e18;
-
-        vm.expectRevert(BalancerFlashloanDirectMintHandler.ExternalBalancerFlashloanNotAllowed.selector);
-        VAULT.flashLoan(
-            IFlashLoanRecipient(address(wstEthHandler)), addresses, amounts, abi.encode(msg.sender, 0, 0, 0)
-        );
-    }
-
-    function testFork_RevertWhen_FlashloanedMoreThanOneToken() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        IERC20Balancer[] memory addresses = new IERC20Balancer[](2);
-        addresses[0] = IERC20Balancer(address(MAINNET_WSTETH));
-        addresses[1] = IERC20Balancer(address(weth));
-
-        uint256[] memory amounts = new uint256[](2);
-        amounts[0] = 8e18;
-        amounts[1] = 8e18;
-
-        vm.expectRevert(abi.encodeWithSelector(BalancerFlashloanDirectMintHandler.FlashLoanedTooManyTokens.selector, 2));
-        VAULT.flashLoan(
-            IFlashLoanRecipient(address(wstEthHandler)), addresses, amounts, abi.encode(msg.sender, 0, 0, 0)
-        );
-    }
-
-    function testFork_RevertWhen_UntrustedCallerCallsFlashloanCallback() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        IERC20Balancer[] memory addresses = new IERC20Balancer[](1);
-        addresses[0] = IERC20Balancer(address(MAINNET_WSTETH));
-
-        uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 8e18;
-
-        vm.expectRevert(
-            abi.encodeWithSelector(BalancerFlashloanDirectMintHandler.ReceiveCallerNotVault.selector, address(this))
-        );
-        wstEthHandler.receiveFlashLoan(addresses, amounts, amounts, "");
-    }
-
-    function testFork_RevertWhen_FlashloanedTokenIsNeitherWethNorCorrectLst() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        IERC20Balancer[] memory addresses = new IERC20Balancer[](1);
-        addresses[0] = IERC20Balancer(address(MAINNET_ETHX));
-
-        uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 8e18;
-
-        // Should actually be impossible
-        vm.expectRevert(BalancerFlashloanDirectMintHandler.ExternalBalancerFlashloanNotAllowed.selector);
-        vm.prank(address(VAULT));
-        wstEthHandler.receiveFlashLoan(addresses, amounts, amounts, abi.encode(address(this), 100e18, 100e18, 100e18));
-    }
-
-    function testFork_RevertWhen_UntrustedCallerCallsFlashswapCallback() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(UniswapFlashswapHandler.CallbackOnlyCallableByPool.selector, address(this))
-        );
-        wstEthHandler.uniswapV3SwapCallback(1, 1, "");
-    }
-
-    function testFork_RevertWhen_TradingInZeroLiquidityRegion() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        vm.prank(address(WSTETH_WETH_POOL));
-        vm.expectRevert(UniswapFlashswapHandler.InvalidZeroLiquidityRegionSwap.selector);
-        wstEthHandler.uniswapV3SwapCallback(0, 0, "");
-    }
-
-    function testFork_RevertWhen_FlashswapLeverageCreatesMoreDebtThanUserIsWilling() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        uint256 initialDeposit = 1e18;
-        uint256 resultingAdditionalCollateral = 5e18;
-        uint256 maxResultingDebt = 3e18; // In weth
-
-        weth.approve(address(wstEthHandler), type(uint256).max);
-        ionPool.addOperator(address(wstEthHandler));
-
-        vm.expectRevert();
-        wstEthHandler.flashswapLeverage(
-            initialDeposit,
-            resultingAdditionalCollateral,
-            maxResultingDebt,
-            sqrtPriceLimitX96,
-            block.timestamp + 1,
-            borrowerWhitelistProof
-        );
-    }
-
-    function testFork_RevertWhen_FlashswapDeleverageSellsMoreCollateralThanUserIsWilling() external {
-        vm.skip(borrowerWhitelistProof.length > 0);
-
-        uint256 initialDeposit = 1e18;
-        uint256 resultingAdditionalCollateral = 5e18;
-        uint256 maxResultingDebt = type(uint256).max;
-
-        weth.approve(address(wstEthHandler), type(uint256).max);
-        ionPool.addOperator(address(wstEthHandler));
-
-        wstEthHandler.flashswapLeverage(
-            initialDeposit,
-            resultingAdditionalCollateral,
-            maxResultingDebt,
-            sqrtPriceLimitX96,
-            block.timestamp + 1,
-            borrowerWhitelistProof
-        );
-
-        uint256 slippageAndFeeTolerance = 1.0e18; // 0%
-        // Want to completely deleverage position and only leave initial capital
-        // in vault
-        uint256 maxCollateralToRemove = (resultingAdditionalCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
-        // Remove all debt
-        uint256 normalizedDebtToRemove = ionPool.normalizedDebt(ilkIndex, address(this));
-
-        // Round up otherwise can leave 1 wei of dust in debt left
-        uint256 debtToRemove = normalizedDebtToRemove.rayMulUp(ionPool.rate(ilkIndex));
-
-        vm.expectRevert();
-        wstEthHandler.flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0, block.timestamp + 1);
+contract WstEthHandler_ForkTest is
+    WstEthHandler_ForkBase,
+    BalancerFlashloanDirectMintHandler_Test,
+    UniswapFlashswapHandler_Test
+{
+    function setUp() public virtual override(WstEthHandler_ForkBase, IonHandler_ForkBase) {
+        super.setUp();
+
+        // If price of the pool ends up being larger than the exchange rate,
+        // then a direct 1:1 contract mint is more favorable
+        uint256 exchangeRate = MAINNET_WSTETH.getStETHByWstETH(1 ether);
+        sqrtPriceLimitX96 = uint160(Math.sqrt(uint256(exchangeRate << 192) / 1e18));
     }
 }
 
@@ -708,7 +353,7 @@ contract WstEthHandler_Zap_ForkTest is WstEthHandler_ForkBase {
             IWstEth(address(MAINNET_WSTETH)).getWstETHByStETH(resultingAdditionalStEthCollateral);
 
         uint256 maxResultingDebt =
-            MAINNET_WSTETH.getEthAmountInForLstAmountOut(resultingAdditionalWstEthCollateral - wstEthDepositAmount);
+            MAINNET_WSTETH.getEthAmountInForLstAmountOut(resultingAdditionalWstEthCollateral - wstEthDepositAmount) * 1.005e18; // Some slippage tolerance
         uint160 sqrtPriceLimitX96 = 0;
 
         IERC20(address(MAINNET_STETH)).approve(address(wstEthHandler), stEthDepositAmount);
@@ -762,7 +407,7 @@ contract WstEthHandler_Zap_ForkTest is WstEthHandler_ForkBase {
             IWstEth(address(MAINNET_WSTETH)).getWstETHByStETH(resultingAdditionalStEthCollateral);
 
         uint256 maxResultingDebt =
-            MAINNET_WSTETH.getEthAmountInForLstAmountOut(resultingAdditionalWstEthCollateral - wstEthDepositAmount);
+            MAINNET_WSTETH.getEthAmountInForLstAmountOut(resultingAdditionalWstEthCollateral - wstEthDepositAmount) * 1.005e18; // Some slippage tolerance
         uint160 sqrtPriceLimitX96 = 0;
 
         IERC20(address(MAINNET_STETH)).approve(address(wstEthHandler), stEthDepositAmount);
@@ -826,7 +471,7 @@ contract WstEthHandlerWhitelist_ForkTest is WstEthHandler_ForkTest, WstEthHandle
         [bytes32(0xa6e6806303186f9c20e1af933c7efa83d98470acf93a10fb8da8b1d9c2873640)]
     ];
 
-    function setUp() public override {
+    function setUp() public override(WstEthHandler_ForkBase, WstEthHandler_ForkTest) {
         super.setUp();
 
         bytes32[] memory borrowerRoots = new bytes32[](1);
@@ -834,7 +479,7 @@ contract WstEthHandlerWhitelist_ForkTest is WstEthHandler_ForkTest, WstEthHandle
 
         // update current whitelist with a new borrower root
         Whitelist _whitelist = Whitelist(ionPool.whitelist());
-        _whitelist.updateBorrowersRoot(0, borrowerWhitelistRoot);
+        _whitelist.updateBorrowersRoot(ilkIndex, borrowerWhitelistRoot);
         _whitelist.approveProtocolWhitelist(address(wstEthHandler));
 
         borrowerWhitelistProof = borrowerProofs[0];

--- a/test/fork/concrete/WstEthHandlerFork.t.sol
+++ b/test/fork/concrete/WstEthHandlerFork.t.sol
@@ -3,12 +3,7 @@ pragma solidity 0.8.21;
 
 import { IWstEth } from "../../../src/interfaces/ProviderInterfaces.sol";
 import { WstEthHandler } from "../../../src/flash/handlers/WstEthHandler.sol";
-import { WadRayMath, WAD, RAY } from "../../../src/libraries/math/WadRayMath.sol";
-import {
-    BalancerFlashloanDirectMintHandler,
-    VAULT
-} from "../../../src/flash/handlers/base/BalancerFlashloanDirectMintHandler.sol";
-import { UniswapFlashswapHandler } from "../../../src/flash/handlers/base/UniswapFlashswapHandler.sol";
+import { WadRayMath, RAY } from "../../../src/libraries/math/WadRayMath.sol";
 import { LidoLibrary } from "../../../src/libraries/LidoLibrary.sol";
 import { Whitelist } from "../../../src/Whitelist.sol";
 import { IonHandlerBase } from "../../../src/flash/handlers/base/IonHandlerBase.sol";
@@ -18,14 +13,8 @@ import { UniswapFlashswapHandler_Test } from "./handlers-base/UniswapFlashswapHa
 import { IonHandler_ForkBase } from "../../helpers/IonHandlerForkBase.sol";
 import { IProviderLibraryExposed } from "../../helpers/IProviderLibraryExposed.sol";
 
-import { IFlashLoanRecipient } from "@balancer-labs/v2-interfaces/contracts/vault/IFlashLoanRecipient.sol";
-import { IERC20 as IERC20Balancer } from "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
-
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
-
-import { Vm } from "forge-std/Vm.sol";
-import { console2 } from "forge-std/console2.sol";
 
 using WadRayMath for uint256;
 using WadRayMath for uint104;

--- a/test/fork/concrete/handlers-base/BalancerFlashloanDirectMintHandler.t.sol
+++ b/test/fork/concrete/handlers-base/BalancerFlashloanDirectMintHandler.t.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import { IonHandler_ForkBase } from "../../../helpers/IonHandlerForkBase.sol";
+import { WadRayMath, RAY } from "../../../../src/libraries/math/WadRayMath.sol";
+import {
+    BalancerFlashloanDirectMintHandler,
+    VAULT
+} from "../../../../src/flash/handlers/base/BalancerFlashloanDirectMintHandler.sol";
+import { Whitelist } from "../../../../src/Whitelist.sol";
+
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+
+import { IFlashLoanRecipient } from "@balancer-labs/v2-interfaces/contracts/vault/IFlashLoanRecipient.sol";
+import { IERC20 as IERC20Balancer } from "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
+
+import { console2 } from "forge-std/console2.sol";
+
+using WadRayMath for uint256;
+
+abstract contract BalancerFlashloanDirectMintHandler_Test is IonHandler_ForkBase {
+    function testFork_FlashloanCollateral() public virtual {
+        uint256 initialDeposit = 1e18; // in ethX
+        uint256 resultingAdditionalCollateral = 5e18; // in ethX
+        uint256 maxResultingDebt =
+            _getProviderLibrary().getEthAmountInForLstAmountOut(resultingAdditionalCollateral - initialDeposit);
+
+        weth.approve(address(_getTypedBFDMHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedBFDMHandler()));
+
+        if (Whitelist(whitelist).borrowersRoot(0) != 0) {
+            vm.expectRevert(abi.encodeWithSelector(Whitelist.NotWhitelistedBorrower.selector, 0, address(this)));
+            _getTypedBFDMHandler().flashLeverageCollateral(
+                initialDeposit, resultingAdditionalCollateral, maxResultingDebt, new bytes32[](0)
+            );
+        }
+
+        uint256 gasBefore = gasleft();
+        _getTypedBFDMHandler().flashLeverageCollateral(
+            initialDeposit, resultingAdditionalCollateral, maxResultingDebt, borrowerWhitelistProof
+        );
+        uint256 gasAfter = gasleft();
+        if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
+
+        uint256 currentRate = ionPool.rate(_getIlkIndex());
+        uint256 roundingError = currentRate / RAY;
+
+        assertGe(
+            ionPool.normalizedDebt(_getIlkIndex(), address(this)).rayMulUp(ionPool.rate(_getIlkIndex())),
+            maxResultingDebt
+        );
+        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(_getTypedBFDMHandler())), 0);
+        assertLe(weth.balanceOf(address(_getTypedBFDMHandler())), roundingError);
+        assertEq(ionPool.collateral(_getIlkIndex(), address(this)), resultingAdditionalCollateral);
+    }
+
+    function testFork_FlashloanWeth() external {
+        uint256 initialDeposit = 1e18; // in ethX
+        uint256 resultingAdditionalCollateral = 5e18; // in ethX
+        uint256 maxResultingDebt =
+            _getProviderLibrary().getEthAmountInForLstAmountOut(resultingAdditionalCollateral - initialDeposit);
+
+        weth.approve(address(_getTypedBFDMHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedBFDMHandler()));
+
+        if (Whitelist(whitelist).borrowersRoot(0) != 0) {
+            vm.expectRevert(abi.encodeWithSelector(Whitelist.NotWhitelistedBorrower.selector, 0, address(this)));
+            _getTypedBFDMHandler().flashLeverageWeth(
+                initialDeposit, resultingAdditionalCollateral, maxResultingDebt, new bytes32[](0)
+            );
+        }
+
+        uint256 gasBefore = gasleft();
+        _getTypedBFDMHandler().flashLeverageWeth(
+            initialDeposit, resultingAdditionalCollateral, maxResultingDebt, borrowerWhitelistProof
+        );
+        uint256 gasAfter = gasleft();
+        if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
+
+        uint256 currentRate = ionPool.rate(_getIlkIndex());
+        uint256 roundingError = currentRate / RAY;
+
+        assertApproxEqAbs(
+            ionPool.normalizedDebt(_getIlkIndex(), address(this)).rayMulDown(ionPool.rate(_getIlkIndex())),
+            maxResultingDebt,
+            roundingError
+        );
+        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(_getTypedBFDMHandler())), 0);
+        assertLe(weth.balanceOf(address(_getTypedBFDMHandler())), roundingError);
+        assertEq(ionPool.collateral(_getIlkIndex(), address(this)), resultingAdditionalCollateral);
+    }
+
+    function testFork_RevertWhen_BalancerFlashloanNotInitiatedByHandler() external {
+        vm.skip(borrowerWhitelistProof.length > 0);
+
+        IERC20Balancer[] memory addresses = new IERC20Balancer[](1);
+        addresses[0] = IERC20Balancer(address(MAINNET_ETHX));
+
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 8e18;
+
+        vm.expectRevert(BalancerFlashloanDirectMintHandler.ExternalBalancerFlashloanNotAllowed.selector);
+        VAULT.flashLoan(
+            IFlashLoanRecipient(address(_getTypedBFDMHandler())), addresses, amounts, abi.encode(msg.sender, 0, 0, 0)
+        );
+    }
+
+    function testFork_RevertWhen_BalancerFlashloanedMoreThanOneToken() external {
+        vm.skip(borrowerWhitelistProof.length > 0);
+
+        IERC20Balancer[] memory addresses = new IERC20Balancer[](2);
+        addresses[0] = IERC20Balancer(address(MAINNET_ETHX));
+        addresses[1] = IERC20Balancer(address(weth));
+
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 8e18;
+        amounts[1] = 8e18;
+
+        vm.expectRevert(abi.encodeWithSelector(BalancerFlashloanDirectMintHandler.FlashLoanedTooManyTokens.selector, 2));
+        VAULT.flashLoan(
+            IFlashLoanRecipient(address(_getTypedBFDMHandler())), addresses, amounts, abi.encode(msg.sender, 0, 0, 0)
+        );
+    }
+
+    function testFork_RevertWhen_UntrustedCallerCallsBalancerFlashloanCallback() external {
+        vm.skip(borrowerWhitelistProof.length > 0);
+
+        IERC20Balancer[] memory addresses = new IERC20Balancer[](1);
+        addresses[0] = IERC20Balancer(address(MAINNET_ETHX));
+
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 8e18;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(BalancerFlashloanDirectMintHandler.ReceiveCallerNotVault.selector, address(this))
+        );
+        _getTypedBFDMHandler().receiveFlashLoan(addresses, amounts, amounts, "");
+    }
+
+    function testFork_RevertWhen_FlashloanedTokenIsNeitherWethNorCorrectLst() external {
+        vm.skip(borrowerWhitelistProof.length > 0);
+
+        IERC20Balancer[] memory addresses = new IERC20Balancer[](1);
+        addresses[0] = IERC20Balancer(address(MAINNET_ETHX));
+
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 8e18;
+
+        // Should actually be impossible
+        vm.expectRevert(BalancerFlashloanDirectMintHandler.ExternalBalancerFlashloanNotAllowed.selector);
+        vm.prank(address(VAULT));
+        _getTypedBFDMHandler().receiveFlashLoan(
+            addresses, amounts, amounts, abi.encode(address(this), 100e18, 100e18, 100e18)
+        );
+    }
+
+    function _getTypedBFDMHandler() private view returns (BalancerFlashloanDirectMintHandler) {
+        return BalancerFlashloanDirectMintHandler(payable(_getHandler()));
+    }
+}

--- a/test/fork/concrete/handlers-base/UniswapFlashloanBalancerSwapHandler.t.sol
+++ b/test/fork/concrete/handlers-base/UniswapFlashloanBalancerSwapHandler.t.sol
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import { IonHandler_ForkBase } from "../../../helpers/IonHandlerForkBase.sol";
+import { WadRayMath, RAY, WAD } from "../../../../src/libraries/math/WadRayMath.sol";
+import { UniswapFlashloanBalancerSwapHandler } from
+    "../../../../src/flash/handlers/base/UniswapFlashloanBalancerSwapHandler.sol";
+import { IonHandlerBase } from "../../../../src/flash/handlers/base/IonHandlerBase.sol";
+import { Whitelist } from "../../../../src/Whitelist.sol";
+
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+
+import { Vm } from "forge-std/Vm.sol";
+import { console2 } from "forge-std/console2.sol";
+
+using WadRayMath for uint256;
+
+abstract contract UniswapFlashloanBalancerSwapHandler_Test is IonHandler_ForkBase {
+    function testFork_FlashswapLeverage() external {
+        uint256 initialDeposit = 1e18;
+        uint256 resultingCollateral = 5e18;
+        uint256 maxResultingDebt = 4.5e18; // In weth
+
+        weth.approve(address(_getTypedUFBSHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedUFBSHandler()));
+
+        vm.expectRevert(abi.encodeWithSelector(IonHandlerBase.TransactionDeadlineReached.selector, block.timestamp));
+        _getTypedUFBSHandler().flashLeverageWethAndSwap(
+            initialDeposit, resultingCollateral, maxResultingDebt, block.timestamp, borrowerWhitelistProof
+        );
+
+        if (Whitelist(whitelist).borrowersRoot(0) != 0) {
+            vm.expectRevert(abi.encodeWithSelector(Whitelist.NotWhitelistedBorrower.selector, 0, address(this)));
+            _getTypedUFBSHandler().flashLeverageWethAndSwap(
+                initialDeposit, resultingCollateral, maxResultingDebt, block.timestamp + 1, borrowerWhitelistProof
+            );
+        }
+
+        uint256 gasBefore = gasleft();
+        _getTypedUFBSHandler().flashLeverageWethAndSwap(
+            initialDeposit, resultingCollateral, maxResultingDebt, block.timestamp + 1, borrowerWhitelistProof
+        );
+        uint256 gasAfter = gasleft();
+        if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
+
+        uint256 currentRate = ionPool.rate(_getIlkIndex());
+        uint256 roundingError = currentRate / RAY;
+
+        assertEq(ionPool.collateral(_getIlkIndex(), address(this)), resultingCollateral);
+        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(_getTypedUFBSHandler())), 0);
+        assertLe(weth.balanceOf(address(_getTypedUFBSHandler())), roundingError);
+        assertLt(
+            ionPool.normalizedDebt(_getIlkIndex(), address(this)).rayMulUp(ionPool.rate(_getIlkIndex())),
+            maxResultingDebt
+        );
+    }
+
+    function testFork_FlashswapDeleverage() external {
+        uint256 initialDeposit = 1e18;
+        uint256 resultingCollateral = 5e18;
+        uint256 maxResultingDebt = type(uint256).max;
+
+        weth.approve(address(_getTypedUFBSHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedUFBSHandler()));
+
+        vm.recordLogs();
+        _getTypedUFBSHandler().flashLeverageWethAndSwap(
+            initialDeposit, resultingCollateral, maxResultingDebt, block.timestamp + 1, borrowerWhitelistProof
+        );
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        uint256 normalizedDebtCreated;
+        for (uint256 i = 0; i < entries.length; i++) {
+            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
+            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
+            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
+        }
+
+        assertEq(ionPool.collateral(_getIlkIndex(), address(this)), resultingCollateral);
+        assertLt(
+            ionPool.normalizedDebt(_getIlkIndex(), address(this)).rayMulUp(ionPool.rate(_getIlkIndex())),
+            maxResultingDebt
+        );
+        assertEq(ionPool.normalizedDebt(_getIlkIndex(), address(this)), normalizedDebtCreated);
+
+        vm.warp(block.timestamp + 3 hours);
+
+        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
+        // Want to completely deleverage position and only leave initial capital
+        // in vault
+        uint256 maxCollateralToRemove = (resultingCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
+        // Remove all debt
+        uint256 normalizedDebtToRemove = ionPool.normalizedDebt(_getIlkIndex(), address(this));
+
+        // Round up otherwise can leave 1 wei of dust in debt left
+        uint256 debtToRemove = normalizedDebtToRemove.rayMulUp(ionPool.rate(_getIlkIndex()));
+
+        vm.expectRevert(abi.encodeWithSelector(IonHandlerBase.TransactionDeadlineReached.selector, block.timestamp));
+        _getTypedUFBSHandler().flashDeleverageWethAndSwap(maxCollateralToRemove, debtToRemove, block.timestamp);
+
+        uint256 gasBefore = gasleft();
+        _getTypedUFBSHandler().flashDeleverageWethAndSwap(maxCollateralToRemove, debtToRemove, block.timestamp + 1);
+        uint256 gasAfter = gasleft();
+        if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
+
+        uint256 currentRate = ionPool.rate(_getIlkIndex());
+        uint256 roundingError = currentRate / RAY;
+
+        assertGe(ionPool.collateral(_getIlkIndex(), address(this)), resultingCollateral - maxCollateralToRemove);
+        assertEq(ionPool.normalizedDebt(_getIlkIndex(), address(this)), 0);
+        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(_getTypedUFBSHandler())), 0);
+        assertLe(weth.balanceOf(address(_getTypedUFBSHandler())), roundingError);
+    }
+
+    function testFork_FlashswapDeleverageFull() external {
+        uint256 initialDeposit = 1e18;
+        uint256 resultingCollateral = 5e18;
+        uint256 maxResultingDebt = type(uint256).max;
+
+        weth.approve(address(_getTypedUFBSHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedUFBSHandler()));
+
+        vm.recordLogs();
+        _getTypedUFBSHandler().flashLeverageWethAndSwap(
+            initialDeposit, resultingCollateral, maxResultingDebt, block.timestamp + 1, borrowerWhitelistProof
+        );
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        uint256 normalizedDebtCreated;
+        for (uint256 i = 0; i < entries.length; i++) {
+            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
+            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
+            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
+        }
+
+        assertEq(ionPool.collateral(_getIlkIndex(), address(this)), resultingCollateral);
+        assertLt(
+            ionPool.normalizedDebt(_getIlkIndex(), address(this)).rayMulUp(ionPool.rate(_getIlkIndex())),
+            maxResultingDebt
+        );
+        assertEq(ionPool.normalizedDebt(_getIlkIndex(), address(this)), normalizedDebtCreated);
+
+        vm.warp(block.timestamp + 3 hours);
+
+        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
+        // Want to completely deleverage position and only leave initial capital
+        // in vault
+        uint256 maxCollateralToRemove = (resultingCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
+
+        // Remove all debt
+        uint256 debtToRemove = type(uint256).max;
+        vm.expectRevert(abi.encodeWithSelector(IonHandlerBase.TransactionDeadlineReached.selector, block.timestamp));
+        _getTypedUFBSHandler().flashDeleverageWethAndSwap(maxCollateralToRemove, debtToRemove, block.timestamp);
+
+        uint256 gasBefore = gasleft();
+        _getTypedUFBSHandler().flashDeleverageWethAndSwap(maxCollateralToRemove, debtToRemove, block.timestamp + 1);
+        uint256 gasAfter = gasleft();
+        if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
+
+        uint256 currentRate = ionPool.rate(_getIlkIndex());
+        uint256 roundingError = currentRate / RAY;
+
+        assertGe(ionPool.collateral(_getIlkIndex(), address(this)), resultingCollateral - maxCollateralToRemove);
+        assertEq(ionPool.normalizedDebt(_getIlkIndex(), address(this)), 0);
+        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(_getTypedUFBSHandler())), 0);
+        assertLe(weth.balanceOf(address(_getTypedUFBSHandler())), roundingError);
+    }
+
+    function testFork_RevertWhen_UntrustedCallerCallsUniswapFlashloanCallback() external {
+        vm.skip(borrowerWhitelistProof.length > 0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(UniswapFlashloanBalancerSwapHandler.ReceiveCallerNotPool.selector, address(this))
+        );
+        _getTypedUFBSHandler().uniswapV3FlashCallback(1, 1, "");
+    }
+
+    function testFork_RevertWhen_FlashswapLeverageCreatesMoreDebtThanUserIsWilling() external {
+        vm.skip(borrowerWhitelistProof.length > 0);
+
+        uint256 initialDeposit = 1e18;
+        uint256 resultingCollateral = 5e18;
+        uint256 maxResultingDebt = 3e18; // In weth
+
+        weth.approve(address(_getTypedUFBSHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedUFBSHandler()));
+
+        vm.expectRevert();
+        _getTypedUFBSHandler().flashLeverageWethAndSwap(
+            initialDeposit, resultingCollateral, maxResultingDebt, block.timestamp + 1, new bytes32[](0)
+        );
+    }
+
+    function testFork_RevertWhen_FlashswapDeleverageSellsMoreCollateralThanUserIsWilling() external {
+        vm.skip(borrowerWhitelistProof.length > 0);
+
+        uint256 initialDeposit = 1e18;
+        uint256 resultingCollateral = 5e18;
+        uint256 maxResultingDebt = type(uint256).max;
+
+        weth.approve(address(_getTypedUFBSHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedUFBSHandler()));
+
+        _getTypedUFBSHandler().flashLeverageWethAndSwap(
+            initialDeposit, resultingCollateral, maxResultingDebt, block.timestamp + 1, new bytes32[](0)
+        );
+
+        // No slippage tolerance
+        uint256 slippageAndFeeTolerance = 1.0e18; // 0%
+        uint256 maxCollateralToRemove = (resultingCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
+        uint256 normalizedDebtToRemove = ionPool.normalizedDebt(_getIlkIndex(), address(this));
+
+        // Round up otherwise can leave 1 wei of dust in debt left
+        uint256 debtToRemove = normalizedDebtToRemove.rayMulUp(ionPool.rate(_getIlkIndex()));
+
+        vm.expectRevert();
+        _getTypedUFBSHandler().flashDeleverageWethAndSwap(maxCollateralToRemove, debtToRemove, block.timestamp + 1);
+    }
+
+    function _getTypedUFBSHandler() private view returns (UniswapFlashloanBalancerSwapHandler) {
+        return UniswapFlashloanBalancerSwapHandler(payable(_getHandler()));
+    }
+}

--- a/test/fork/concrete/handlers-base/UniswapFlashswapHandler.t.sol
+++ b/test/fork/concrete/handlers-base/UniswapFlashswapHandler.t.sol
@@ -9,9 +9,6 @@ import { Whitelist } from "../../../../src/Whitelist.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 
-import { IFlashLoanRecipient } from "@balancer-labs/v2-interfaces/contracts/vault/IFlashLoanRecipient.sol";
-import { IERC20 as IERC20Balancer } from "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
-
 import { Vm } from "forge-std/Vm.sol";
 import { console2 } from "forge-std/console2.sol";
 

--- a/test/fork/concrete/handlers-base/UniswapFlashswapHandler.t.sol
+++ b/test/fork/concrete/handlers-base/UniswapFlashswapHandler.t.sol
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import { IonHandler_ForkBase } from "../../../helpers/IonHandlerForkBase.sol";
+import { WadRayMath, RAY, WAD } from "../../../../src/libraries/math/WadRayMath.sol";
+import { UniswapFlashswapHandler } from "../../../../src/flash/handlers/base/UniswapFlashswapHandler.sol";
+import { IonHandlerBase } from "../../../../src/flash/handlers/base/IonHandlerBase.sol";
+import { Whitelist } from "../../../../src/Whitelist.sol";
+
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+
+import { IFlashLoanRecipient } from "@balancer-labs/v2-interfaces/contracts/vault/IFlashLoanRecipient.sol";
+import { IERC20 as IERC20Balancer } from "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
+
+import { Vm } from "forge-std/Vm.sol";
+import { console2 } from "forge-std/console2.sol";
+
+using WadRayMath for uint256;
+
+abstract contract UniswapFlashswapHandler_Test is IonHandler_ForkBase {
+    uint160 sqrtPriceLimitX96;
+
+    function testFork_FlashswapLeverage() external {
+        uint256 initialDeposit = 1e18;
+        uint256 resultingAdditionalCollateral = 5e18;
+        uint256 maxResultingDebt = 6e18; // In weth
+
+        weth.approve(address(_getTypedUFHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedUFHandler()));
+
+        vm.expectRevert(abi.encodeWithSelector(IonHandlerBase.TransactionDeadlineReached.selector, block.timestamp));
+        _getTypedUFHandler().flashswapLeverage(
+            initialDeposit,
+            resultingAdditionalCollateral,
+            maxResultingDebt,
+            sqrtPriceLimitX96,
+            block.timestamp,
+            borrowerWhitelistProof
+        );
+
+        if (Whitelist(whitelist).borrowersRoot(0) != 0) {
+            vm.expectRevert(abi.encodeWithSelector(Whitelist.NotWhitelistedBorrower.selector, 0, address(this)));
+            _getTypedUFHandler().flashswapLeverage(
+                initialDeposit,
+                resultingAdditionalCollateral,
+                maxResultingDebt,
+                sqrtPriceLimitX96,
+                block.timestamp + 1,
+                new bytes32[](0)
+            );
+        }
+
+        uint256 gasBefore = gasleft();
+        _getTypedUFHandler().flashswapLeverage(
+            initialDeposit,
+            resultingAdditionalCollateral,
+            maxResultingDebt,
+            sqrtPriceLimitX96,
+            block.timestamp + 1,
+            borrowerWhitelistProof
+        );
+        uint256 gasAfter = gasleft();
+        if (vm.envOr("SHOW_GAS", uint256(0)) == 1) console2.log("Gas used: %d", gasBefore - gasAfter);
+
+        uint256 currentRate = ionPool.rate(_getIlkIndex());
+        uint256 roundingError = currentRate / RAY;
+
+        assertEq(ionPool.collateral(_getIlkIndex(), address(this)), resultingAdditionalCollateral);
+        assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(_getTypedUFHandler())), 0);
+        assertLe(weth.balanceOf(address(_getTypedUFHandler())), roundingError);
+        assertLt(
+            ionPool.normalizedDebt(_getIlkIndex(), address(this)).rayMulUp(ionPool.rate(_getIlkIndex())),
+            maxResultingDebt
+        );
+    }
+
+    function testFork_FlashswapDeleverage() external {
+        uint256 initialDeposit = 1e18;
+        uint256 resultingAdditionalCollateral = 5e18;
+        uint256 maxResultingDebt = type(uint256).max;
+
+        weth.approve(address(_getTypedUFHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedUFHandler()));
+
+        vm.recordLogs();
+        _getTypedUFHandler().flashswapLeverage(
+            initialDeposit,
+            resultingAdditionalCollateral,
+            maxResultingDebt,
+            sqrtPriceLimitX96,
+            block.timestamp + 1,
+            borrowerWhitelistProof
+        );
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        uint256 normalizedDebtCreated;
+        for (uint256 i = 0; i < entries.length; i++) {
+            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
+            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
+            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
+        }
+
+        assertEq(ionPool.collateral(_getIlkIndex(), address(this)), resultingAdditionalCollateral);
+        assertLt(
+            ionPool.normalizedDebt(_getIlkIndex(), address(this)).rayMulUp(ionPool.rate(_getIlkIndex())),
+            maxResultingDebt
+        );
+        assertEq(ionPool.normalizedDebt(_getIlkIndex(), address(this)), normalizedDebtCreated);
+
+        vm.warp(block.timestamp + 3 hours);
+
+        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
+        // Want to completely deleverage position and only leave initial capital
+        // in vault
+        uint256 maxCollateralToRemove = (resultingAdditionalCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
+        // Remove all debt
+        uint256 normalizedDebtToRemove = ionPool.normalizedDebt(_getIlkIndex(), address(this));
+
+        // Round up otherwise can leave 1 wei of dust in debt left
+        uint256 debtToRemove = normalizedDebtToRemove.rayMulUp(ionPool.rate(_getIlkIndex()));
+
+        vm.expectRevert(abi.encodeWithSelector(IonHandlerBase.TransactionDeadlineReached.selector, block.timestamp));
+        _getTypedUFHandler().flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0, block.timestamp);
+
+        _getTypedUFHandler().flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0, block.timestamp + 1);
+
+        uint256 currentRate = ionPool.rate(_getIlkIndex());
+        uint256 roundingError = currentRate / RAY;
+
+        assertGe(
+            ionPool.collateral(_getIlkIndex(), address(this)), resultingAdditionalCollateral - maxCollateralToRemove
+        );
+        assertEq(ionPool.normalizedDebt(_getIlkIndex(), address(this)), 0);
+        assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(_getTypedUFHandler())), 0);
+        assertLe(weth.balanceOf(address(_getTypedUFHandler())), roundingError);
+    }
+
+    function testFork_FlashswapDeleverageFull() external {
+        uint256 initialDeposit = 1e18;
+        uint256 resultingAdditionalCollateral = 5e18;
+        uint256 maxResultingDebt = type(uint256).max;
+
+        weth.approve(address(_getTypedUFHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedUFHandler()));
+
+        vm.recordLogs();
+        _getTypedUFHandler().flashswapLeverage(
+            initialDeposit,
+            resultingAdditionalCollateral,
+            maxResultingDebt,
+            sqrtPriceLimitX96,
+            block.timestamp + 1,
+            borrowerWhitelistProof
+        );
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        uint256 normalizedDebtCreated;
+        for (uint256 i = 0; i < entries.length; i++) {
+            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
+            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
+            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
+        }
+
+        assertEq(ionPool.collateral(_getIlkIndex(), address(this)), resultingAdditionalCollateral);
+        assertLt(
+            ionPool.normalizedDebt(_getIlkIndex(), address(this)).rayMulUp(ionPool.rate(_getIlkIndex())),
+            maxResultingDebt
+        );
+        assertEq(ionPool.normalizedDebt(_getIlkIndex(), address(this)), normalizedDebtCreated);
+
+        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
+        // Want to completely deleverage position and only leave initial capital
+        // in vault
+        uint256 maxCollateralToRemove = (resultingAdditionalCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
+
+        // Remove all debt
+        uint256 debtToRemove = type(uint256).max;
+
+        _getTypedUFHandler().flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0, block.timestamp + 1);
+
+        uint256 currentRate = ionPool.rate(_getIlkIndex());
+        uint256 roundingError = currentRate / RAY;
+
+        assertGe(
+            ionPool.collateral(_getIlkIndex(), address(this)), resultingAdditionalCollateral - maxCollateralToRemove
+        );
+        assertEq(ionPool.normalizedDebt(_getIlkIndex(), address(this)), 0);
+        assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(_getTypedUFHandler())), 0);
+        assertLe(weth.balanceOf(address(_getTypedUFHandler())), roundingError);
+    }
+
+    function testFork_RevertWhen_UntrustedCallerCallsFlashswapCallback() external {
+        vm.skip(borrowerWhitelistProof.length > 0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(UniswapFlashswapHandler.CallbackOnlyCallableByPool.selector, address(this))
+        );
+        _getTypedUFHandler().uniswapV3SwapCallback(1, 1, "");
+    }
+
+    function testFork_RevertWhen_TradingInZeroLiquidityRegion() external {
+        vm.skip(borrowerWhitelistProof.length > 0);
+
+        vm.prank(address(_getUniswapPools()[_getIlkIndex()]));
+        vm.expectRevert(UniswapFlashswapHandler.InvalidZeroLiquidityRegionSwap.selector);
+        _getTypedUFHandler().uniswapV3SwapCallback(0, 0, "");
+    }
+
+    function testFork_RevertWhen_FlashswapLeverageCreatesMoreDebtThanUserIsWilling() external {
+        vm.skip(borrowerWhitelistProof.length > 0);
+
+        uint256 initialDeposit = 1e18;
+        uint256 resultingAdditionalCollateral = 5e18;
+        uint256 maxResultingDebt = 3e18; // In weth
+
+        weth.approve(address(_getTypedUFHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedUFHandler()));
+
+        vm.expectRevert();
+        _getTypedUFHandler().flashswapLeverage(
+            initialDeposit,
+            resultingAdditionalCollateral,
+            maxResultingDebt,
+            sqrtPriceLimitX96,
+            block.timestamp + 1,
+            new bytes32[](0)
+        );
+    }
+
+    function testFork_RevertWhen_FlashswapDeleverageSellsMoreCollateralThanUserIsWilling() external {
+        vm.skip(borrowerWhitelistProof.length > 0);
+
+        uint256 initialDeposit = 1e18;
+        uint256 resultingAdditionalCollateral = 5e18;
+        uint256 maxResultingDebt = type(uint256).max;
+
+        weth.approve(address(_getTypedUFHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedUFHandler()));
+
+        _getTypedUFHandler().flashswapLeverage(
+            initialDeposit,
+            resultingAdditionalCollateral,
+            maxResultingDebt,
+            sqrtPriceLimitX96,
+            block.timestamp + 1,
+            new bytes32[](0)
+        );
+
+        uint256 slippageAndFeeTolerance = 1.0e18; // 0%
+        // Want to completely deleverage position and only leave initial capital
+        // in vault
+        uint256 maxCollateralToRemove = (resultingAdditionalCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
+        // Remove all debt
+        uint256 normalizedDebtToRemove = ionPool.normalizedDebt(_getIlkIndex(), address(this));
+
+        // Round up otherwise can leave 1 wei of dust in debt left
+        uint256 debtToRemove = normalizedDebtToRemove.rayMulUp(ionPool.rate(_getIlkIndex()));
+
+        vm.expectRevert();
+        _getTypedUFHandler().flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0, block.timestamp + 1);
+    }
+
+    function _getTypedUFHandler() private view returns (UniswapFlashswapHandler) {
+        return UniswapFlashswapHandler(payable(_getHandler()));
+    }
+}

--- a/test/fork/fuzz/EthXHandlerForkFuzz.t.sol
+++ b/test/fork/fuzz/EthXHandlerForkFuzz.t.sol
@@ -3,9 +3,7 @@ pragma solidity 0.8.21;
 
 import { EthXHandler_ForkBase } from "../../fork/concrete/EthXHandlerFork.t.sol";
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
-import { WadRayMath, WAD, RAY } from "../../../src/libraries/math/WadRayMath.sol";
+import { WadRayMath } from "../../../src/libraries/math/WadRayMath.sol";
 import { IStaderStakePoolsManager } from "../../../src/interfaces/ProviderInterfaces.sol";
 import { StaderLibrary } from "../../../src/libraries/StaderLibrary.sol";
 import { IonHandler_ForkBase } from "../../helpers/IonHandlerForkBase.sol";
@@ -21,8 +19,6 @@ import {
     UniswapFlashloanBalancerSwapHandler_FuzzTest,
     UniswapFlashloanBalancerSwapHandler_WithRateChange_FuzzTest
 } from "./handlers-base/UniswapFlashloanBalancerSwapHandler.t.sol";
-
-import { Vm } from "forge-std/Vm.sol";
 
 using StaderLibrary for IStaderStakePoolsManager;
 

--- a/test/fork/fuzz/EthXHandlerForkFuzz.t.sol
+++ b/test/fork/fuzz/EthXHandlerForkFuzz.t.sol
@@ -8,254 +8,53 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { WadRayMath, WAD, RAY } from "../../../src/libraries/math/WadRayMath.sol";
 import { IStaderStakePoolsManager } from "../../../src/interfaces/ProviderInterfaces.sol";
 import { StaderLibrary } from "../../../src/libraries/StaderLibrary.sol";
+import { IonHandler_ForkBase } from "../../helpers/IonHandlerForkBase.sol";
+import {
+    BalancerFlashloanDirectMintHandler_FuzzTest,
+    BalancerFlashloanDirectMintHandler_WithRateChange_FuzzTest
+} from "./handlers-base/BalancerFlashloanDirectMintHandler.t.sol";
+import {
+    UniswapFlashswapHandler_FuzzTest,
+    UniswapFlashswapHandler_WithRateChange_FuzzTest
+} from "./handlers-base/UniswapFlashswapHandler.t.sol";
+import {
+    UniswapFlashloanBalancerSwapHandler_FuzzTest,
+    UniswapFlashloanBalancerSwapHandler_WithRateChange_FuzzTest
+} from "./handlers-base/UniswapFlashloanBalancerSwapHandler.t.sol";
 
 import { Vm } from "forge-std/Vm.sol";
 
 using StaderLibrary for IStaderStakePoolsManager;
 
-abstract contract EthXHandler_ForkFuzzTest is EthXHandler_ForkBase {
+abstract contract EthXHandler_ForkFuzzTest is
+    EthXHandler_ForkBase,
+    BalancerFlashloanDirectMintHandler_FuzzTest,
+    UniswapFlashloanBalancerSwapHandler_FuzzTest,
+    UniswapFlashswapHandler_FuzzTest
+{
     using WadRayMath for *;
 
     uint256 minDeposit;
     uint256 maxDeposit;
 
-    function setUp() public override {
+    function setUp() public virtual override(EthXHandler_ForkBase, IonHandler_ForkBase) {
         super.setUp();
 
         minDeposit = MAINNET_STADER.staderConfig().getMinDepositAmount();
         maxDeposit = MAINNET_STADER.staderConfig().getMaxDepositAmount();
     }
-
-    function testForkFuzz_FlashLoanCollateral(uint256 initialDeposit, uint256 resultingCollateralMultiplier) public {
-        initialDeposit = bound(initialDeposit, minDeposit, INITIAL_THIS_UNDERLYING_BALANCE);
-        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
-        uint256 resultingDebt = MAINNET_STADER.getEthAmountInForLstAmountOut(resultingCollateral - initialDeposit);
-
-        uint256 ilkRate = ionPool.rate(ilkIndex);
-        uint256 ilkSpot = ionPool.spot(ilkIndex).getSpot();
-        // Calculating this way emulates the newTotalDebt value in IonPool
-        uint256 newTotalDebt = resultingDebt.rayDivUp(ilkRate) * ilkRate;
-
-        bool unsafePositionChange = newTotalDebt > resultingCollateral * ilkSpot;
-
-        vm.assume(!unsafePositionChange);
-
-        weth.approve(address(ethXHandler), type(uint256).max);
-        ionPool.addOperator(address(ethXHandler));
-
-        ethXHandler.flashLeverageCollateral(initialDeposit, resultingCollateral, resultingDebt, new bytes32[](0));
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertGe(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), resultingDebt);
-        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(ethXHandler)), 0);
-        assertLe(weth.balanceOf(address(ethXHandler)), roundingError);
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-    }
-
-    function testForkFuzz_FlashLoanWeth(uint256 initialDeposit, uint256 resultingCollateralMultiplier) public {
-        initialDeposit = bound(initialDeposit, minDeposit, INITIAL_THIS_UNDERLYING_BALANCE);
-        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
-        uint256 resultingDebt = MAINNET_STADER.getEthAmountInForLstAmountOut(resultingCollateral - initialDeposit);
-
-        uint256 ilkRate = ionPool.rate(ilkIndex);
-        uint256 ilkSpot = ionPool.spot(ilkIndex).getSpot();
-        uint256 newTotalDebt = resultingDebt.rayDivUp(ilkRate) * ilkRate;
-
-        bool unsafePositionChange = newTotalDebt > resultingCollateral * ilkSpot;
-
-        weth.approve(address(ethXHandler), type(uint256).max);
-        ionPool.addOperator(address(ethXHandler));
-
-        vm.assume(!unsafePositionChange);
-
-        ethXHandler.flashLeverageWeth(initialDeposit, resultingCollateral, resultingDebt, new bytes32[](0));
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertApproxEqAbs(
-            ionPool.normalizedDebt(ilkIndex, address(this)).rayMulDown(ionPool.rate(ilkIndex)),
-            resultingDebt,
-            ilkRate / RAY
-        );
-        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(ethXHandler)), 0);
-        assertLe(weth.balanceOf(address(ethXHandler)), roundingError);
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-    }
-
-    function testForkFuzz_FlashSwapLeverage(uint256 initialDeposit, uint256 resultingCollateralMultiplier) public {
-        initialDeposit = bound(initialDeposit, minDeposit, INITIAL_THIS_UNDERLYING_BALANCE);
-        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
-        uint256 maxResultingDebt = resultingCollateral; // in weth. This is technically subject to slippage but we will
-            // skip protecting for this in the test
-
-        weth.approve(address(ethXHandler), type(uint256).max);
-        ionPool.addOperator(address(ethXHandler));
-
-        ethXHandler.flashLeverageWethAndSwap(
-            initialDeposit, resultingCollateral, maxResultingDebt, block.timestamp + 1, new bytes32[](0)
-        );
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(ethXHandler)), 0);
-        assertLe(weth.balanceOf(address(ethXHandler)), roundingError);
-        assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
-    }
-
-    function testForkFuzz_FlashSwapDeleverage(uint256 initialDeposit, uint256 resultingCollateralMultiplier) public {
-        initialDeposit = bound(initialDeposit, minDeposit, INITIAL_THIS_UNDERLYING_BALANCE);
-        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
-        uint256 maxResultingDebt = resultingCollateral; // in weth. This is technically subject to slippage but we will
-            // skip protecting for this in the test
-
-        weth.approve(address(ethXHandler), type(uint256).max);
-        ionPool.addOperator(address(ethXHandler));
-
-        vm.recordLogs();
-        ethXHandler.flashLeverageWethAndSwap(
-            initialDeposit, resultingCollateral, maxResultingDebt, block.timestamp + 1, new bytes32[](0)
-        );
-
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-
-        uint256 normalizedDebtCreated;
-        for (uint256 i = 0; i < entries.length; i++) {
-            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
-            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
-            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
-        }
-
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-        assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), normalizedDebtCreated);
-
-        vm.warp(block.timestamp + 3 hours);
-
-        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
-        // Want to completely deleverage position and only leave initial capital
-        // in vault
-        uint256 maxCollateralToRemove = (resultingCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
-        // Remove all debt
-        uint256 normalizedDebtToRemove = ionPool.normalizedDebt(ilkIndex, address(this));
-
-        // Round up otherwise can leave 1 wei of dust in debt left
-        uint256 debtToRemove = normalizedDebtToRemove.rayMulUp(ionPool.rate(ilkIndex));
-
-        ethXHandler.flashDeleverageWethAndSwap(maxCollateralToRemove, debtToRemove, block.timestamp + 1);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertGe(ionPool.collateral(ilkIndex, address(this)), resultingCollateral - maxCollateralToRemove);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), 0);
-        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(ethXHandler)), 0);
-        assertLe(weth.balanceOf(address(ethXHandler)), roundingError);
-    }
-
-    function testForkFuzz_FlashSwapDeleverageFull(
-        uint256 initialDeposit,
-        uint256 resultingCollateralMultiplier
-    )
-        public
-    {
-        initialDeposit = bound(initialDeposit, minDeposit, INITIAL_THIS_UNDERLYING_BALANCE);
-        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
-        uint256 maxResultingDebt = resultingCollateral; // in weth. This is technically subject to slippage but we will
-            // skip protecting for this in the test
-
-        weth.approve(address(ethXHandler), type(uint256).max);
-        ionPool.addOperator(address(ethXHandler));
-
-        vm.recordLogs();
-        ethXHandler.flashLeverageWethAndSwap(
-            initialDeposit, resultingCollateral, maxResultingDebt, block.timestamp + 1, new bytes32[](0)
-        );
-
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-
-        uint256 normalizedDebtCreated;
-        for (uint256 i = 0; i < entries.length; i++) {
-            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
-            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
-            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
-        }
-
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-        assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), normalizedDebtCreated);
-
-        vm.warp(block.timestamp + 3 hours);
-
-        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
-        // Want to completely deleverage position and only leave initial capital
-        // in vault
-        uint256 maxCollateralToRemove = (resultingCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
-        // Remove all debt
-        uint256 debtToRemove = type(uint256).max;
-
-        ethXHandler.flashDeleverageWethAndSwap(maxCollateralToRemove, debtToRemove, block.timestamp + 1);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertGe(ionPool.collateral(ilkIndex, address(this)), resultingCollateral - maxCollateralToRemove);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), 0);
-        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(ethXHandler)), 0);
-        assertLe(weth.balanceOf(address(ethXHandler)), roundingError);
-    }
 }
 
-contract EthXHandler_WithRateChange_ForkFuzzTest is EthXHandler_ForkFuzzTest {
-    function testForkFuzz_WithRateChange_FlashLoanCollateral(
-        uint256 initialDeposit,
-        uint256 resultingCollateralMultiplier,
-        uint104 rate
-    )
-        external
-    {
-        rate = uint104(bound(rate, 1e27, 10e27));
-        ionPool.setRate(ilkIndex, rate);
-        super.testForkFuzz_FlashLoanCollateral(initialDeposit, resultingCollateralMultiplier);
-    }
-
-    function testForkFuzz_WithRateChange_FlashLoanWeth(
-        uint256 initialDeposit,
-        uint256 resultingCollateralMultiplier,
-        uint104 rate
-    )
-        external
-    {
-        rate = uint104(bound(rate, 1e27, 10e27));
-        ionPool.setRate(ilkIndex, rate);
-        super.testForkFuzz_FlashLoanWeth(initialDeposit, resultingCollateralMultiplier);
-    }
-
-    function testForkFuzz_WithRateChange_FlashSwapLeverage(
-        uint256 initialDeposit,
-        uint256 resultingCollateralMultiplier,
-        uint104 rate
-    )
-        external
-    {
-        rate = uint104(bound(rate, 1e27, 10e27));
-        ionPool.setRate(ilkIndex, rate);
-        super.testForkFuzz_FlashSwapLeverage(initialDeposit, resultingCollateralMultiplier);
-    }
-
-    function testForkFuzz_WithRateChange_FlashSwapDeleverage(
-        uint256 initialDeposit,
-        uint256 resultingCollateralMultiplier,
-        uint104 rate
-    )
-        external
-    {
-        rate = uint104(bound(rate, 1e27, 10e27));
-        ionPool.setRate(ilkIndex, rate);
-        super.testForkFuzz_FlashSwapDeleverage(initialDeposit, resultingCollateralMultiplier);
+contract EthXHandler_WithRateChange_ForkFuzzTest is
+    EthXHandler_ForkFuzzTest,
+    BalancerFlashloanDirectMintHandler_WithRateChange_FuzzTest,
+    UniswapFlashloanBalancerSwapHandler_WithRateChange_FuzzTest,
+    UniswapFlashswapHandler_WithRateChange_FuzzTest
+{
+    function setUp() public override(EthXHandler_ForkFuzzTest, IonHandler_ForkBase) {
+        super.setUp();
+        ufbsConfig.initialDepositLowerBound = minDeposit;
+        ufConfig.initialDepositLowerBound = minDeposit;
+        bfdmConfig.initialDepositLowerBound = minDeposit;
     }
 }

--- a/test/fork/fuzz/SwEthHandlerForkFuzz.t.sol
+++ b/test/fork/fuzz/SwEthHandlerForkFuzz.t.sol
@@ -3,9 +3,6 @@ pragma solidity 0.8.21;
 
 import { SwEthHandler_ForkBase } from "../../fork/concrete/SwEthHandlerFork.t.sol";
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
-import { WadRayMath, WAD, RAY } from "../../../src/libraries/math/WadRayMath.sol";
 import { ISwEth } from "../../../src/interfaces/ProviderInterfaces.sol";
 import { SwellLibrary } from "../../../src/libraries/SwellLibrary.sol";
 import { IonHandler_ForkBase } from "../../helpers/IonHandlerForkBase.sol";
@@ -18,17 +15,13 @@ import {
     UniswapFlashswapHandler_WithRateChange_FuzzTest
 } from "./handlers-base/UniswapFlashswapHandler.t.sol";
 
-import { Vm } from "forge-std/Vm.sol";
-
 using SwellLibrary for ISwEth;
 
 abstract contract SwEthHandler_ForkFuzzTest is
     SwEthHandler_ForkBase,
-    BalancerFlashloanDirectMintHandler_WithRateChange_FuzzTest,
-    UniswapFlashswapHandler_WithRateChange_FuzzTest
+    BalancerFlashloanDirectMintHandler_FuzzTest,
+    UniswapFlashswapHandler_FuzzTest
 {
-    using WadRayMath for *;
-
     function setUp() public virtual override(IonHandler_ForkBase, SwEthHandler_ForkBase) {
         super.setUp();
     }

--- a/test/fork/fuzz/SwEthHandlerForkFuzz.t.sol
+++ b/test/fork/fuzz/SwEthHandlerForkFuzz.t.sol
@@ -8,259 +8,40 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { WadRayMath, WAD, RAY } from "../../../src/libraries/math/WadRayMath.sol";
 import { ISwEth } from "../../../src/interfaces/ProviderInterfaces.sol";
 import { SwellLibrary } from "../../../src/libraries/SwellLibrary.sol";
+import { IonHandler_ForkBase } from "../../helpers/IonHandlerForkBase.sol";
+import {
+    BalancerFlashloanDirectMintHandler_FuzzTest,
+    BalancerFlashloanDirectMintHandler_WithRateChange_FuzzTest
+} from "./handlers-base/BalancerFlashloanDirectMintHandler.t.sol";
+import {
+    UniswapFlashswapHandler_FuzzTest,
+    UniswapFlashswapHandler_WithRateChange_FuzzTest
+} from "./handlers-base/UniswapFlashswapHandler.t.sol";
 
 import { Vm } from "forge-std/Vm.sol";
 
 using SwellLibrary for ISwEth;
 
-abstract contract SwEthHandler_ForkFuzzTest is SwEthHandler_ForkBase {
+abstract contract SwEthHandler_ForkFuzzTest is
+    SwEthHandler_ForkBase,
+    BalancerFlashloanDirectMintHandler_WithRateChange_FuzzTest,
+    UniswapFlashswapHandler_WithRateChange_FuzzTest
+{
     using WadRayMath for *;
 
-    function testForkFuzz_FlashLoanCollateral(uint256 initialDeposit, uint256 resultingCollateralMultiplier) public {
-        initialDeposit = bound(initialDeposit, 4 wei, INITIAL_THIS_UNDERLYING_BALANCE);
-        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
-        uint256 resultingDebt = MAINNET_SWELL.getEthAmountInForLstAmountOut(resultingCollateral - initialDeposit);
-
-        uint256 ilkRate = ionPool.rate(ilkIndex);
-        uint256 ilkSpot = ionPool.spot(ilkIndex).getSpot();
-        // Calculating this way emulates the newTotalDebt value in IonPool
-        uint256 newTotalDebt = resultingDebt.rayDivUp(ilkRate) * ilkRate;
-
-        bool unsafePositionChange = newTotalDebt > resultingCollateral * ilkSpot;
-
-        vm.assume(!unsafePositionChange);
-
-        weth.approve(address(swEthHandler), type(uint256).max);
-        ionPool.addOperator(address(swEthHandler));
-
-        swEthHandler.flashLeverageCollateral(initialDeposit, resultingCollateral, resultingDebt, new bytes32[](0));
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertGe(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), resultingDebt);
-        assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(swEthHandler)), 0);
-        assertLe(weth.balanceOf(address(swEthHandler)), roundingError);
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-    }
-
-    function testForkFuzz_FlashLoanWeth(uint256 initialDeposit, uint256 resultingCollateralMultiplier) public {
-        initialDeposit = bound(initialDeposit, 4 wei, INITIAL_THIS_UNDERLYING_BALANCE);
-        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
-        uint256 resultingDebt = MAINNET_SWELL.getEthAmountInForLstAmountOut(resultingCollateral - initialDeposit);
-
-        uint256 ilkRate = ionPool.rate(ilkIndex);
-        uint256 ilkSpot = ionPool.spot(ilkIndex).getSpot();
-        uint256 newTotalDebt = resultingDebt.rayDivUp(ilkRate) * ilkRate;
-
-        bool unsafePositionChange = newTotalDebt > resultingCollateral * ilkSpot;
-
-        weth.approve(address(swEthHandler), type(uint256).max);
-        ionPool.addOperator(address(swEthHandler));
-
-        vm.assume(!unsafePositionChange);
-
-        swEthHandler.flashLeverageWeth(initialDeposit, resultingCollateral, resultingDebt, new bytes32[](0));
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertApproxEqAbs(
-            ionPool.normalizedDebt(ilkIndex, address(this)).rayMulDown(ionPool.rate(ilkIndex)),
-            resultingDebt,
-            ilkRate / RAY
-        );
-        assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(swEthHandler)), 0);
-        assertLe(weth.balanceOf(address(swEthHandler)), roundingError);
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-    }
-
-    function testForkFuzz_FlashSwapLeverage(uint256 initialDeposit, uint256 resultingCollateralMultiplier) public {
-        initialDeposit = bound(initialDeposit, 1e13, INITIAL_THIS_UNDERLYING_BALANCE);
-        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
-        uint256 maxResultingDebt = resultingCollateral; // in weth. This is technically subject to slippage but we will
-            // skip protecting for this in the test
-
-        weth.approve(address(swEthHandler), type(uint256).max);
-        ionPool.addOperator(address(swEthHandler));
-
-        swEthHandler.flashswapLeverage(
-            initialDeposit,
-            resultingCollateral,
-            maxResultingDebt,
-            sqrtPriceLimitX96,
-            block.timestamp + 1,
-            new bytes32[](0)
-        );
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-        assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(swEthHandler)), 0);
-        assertLe(weth.balanceOf(address(swEthHandler)), roundingError);
-        assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
-    }
-
-    function testForkFuzz_FlashSwapDeleverage(uint256 initialDeposit, uint256 resultingCollateralMultiplier) public {
-        initialDeposit = bound(initialDeposit, 1e13, INITIAL_THIS_UNDERLYING_BALANCE);
-        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
-        uint256 maxResultingDebt = resultingCollateral; // in weth. This is technically subject to slippage but we will
-            // skip protecting for this in the test
-
-        weth.approve(address(swEthHandler), type(uint256).max);
-        ionPool.addOperator(address(swEthHandler));
-
-        vm.recordLogs();
-        swEthHandler.flashswapLeverage(
-            initialDeposit,
-            resultingCollateral,
-            maxResultingDebt,
-            sqrtPriceLimitX96,
-            block.timestamp + 1,
-            new bytes32[](0)
-        );
-
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-
-        uint256 normalizedDebtCreated;
-        for (uint256 i = 0; i < entries.length; i++) {
-            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
-            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
-            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
-        }
-
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-        assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), normalizedDebtCreated);
-
-        vm.warp(block.timestamp + 3 hours);
-
-        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
-        // Want to completely deleverage position and only leave initial capital
-        // in vault
-        uint256 maxCollateralToRemove = (resultingCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
-        // Remove all debt
-        uint256 normalizedDebtToRemove = ionPool.normalizedDebt(ilkIndex, address(this));
-
-        // Round up otherwise can leave 1 wei of dust in debt left
-        uint256 debtToRemove = normalizedDebtToRemove.rayMulUp(ionPool.rate(ilkIndex));
-
-        swEthHandler.flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0, block.timestamp + 1);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertGe(ionPool.collateral(ilkIndex, address(this)), resultingCollateral - maxCollateralToRemove);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), 0);
-        assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(swEthHandler)), 0);
-        assertLe(weth.balanceOf(address(swEthHandler)), roundingError);
-    }
-
-    function testForkFuzz_FlashSwapDeleverageFull(
-        uint256 initialDeposit,
-        uint256 resultingCollateralMultiplier
-    )
-        public
-    {
-        initialDeposit = bound(initialDeposit, 1e13, INITIAL_THIS_UNDERLYING_BALANCE);
-        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
-        uint256 maxResultingDebt = resultingCollateral; // in weth. This is technically subject to slippage but we will
-            // skip protecting for this in the test
-
-        weth.approve(address(swEthHandler), type(uint256).max);
-        ionPool.addOperator(address(swEthHandler));
-
-        vm.recordLogs();
-        swEthHandler.flashswapLeverage(
-            initialDeposit,
-            resultingCollateral,
-            maxResultingDebt,
-            sqrtPriceLimitX96,
-            block.timestamp + 1,
-            new bytes32[](0)
-        );
-
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-
-        uint256 normalizedDebtCreated;
-        for (uint256 i = 0; i < entries.length; i++) {
-            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
-            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
-            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
-        }
-
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-        assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), normalizedDebtCreated);
-
-        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
-        // Want to completely deleverage position and only leave initial capital
-        // in vault
-        uint256 maxCollateralToRemove = (resultingCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
-        uint256 normalizedDebtCurrent = ionPool.normalizedDebt(ilkIndex, address(this));
-
-        // Remove all debt if any
-        uint256 debtToRemove = normalizedDebtCurrent == 0 ? 0 : type(uint256).max;
-
-        swEthHandler.flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0, block.timestamp + 1);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertGe(ionPool.collateral(ilkIndex, address(this)), resultingCollateral - maxCollateralToRemove);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), 0);
-        assertEq(IERC20(address(MAINNET_SWELL)).balanceOf(address(swEthHandler)), 0);
-        assertLe(weth.balanceOf(address(swEthHandler)), roundingError);
+    function setUp() public virtual override(IonHandler_ForkBase, SwEthHandler_ForkBase) {
+        super.setUp();
     }
 }
 
-contract SwEthHandler_WithRateChange_ForkFuzzTest is SwEthHandler_ForkFuzzTest {
-    function testForkFuzz_WithRateChange_FlashLoanCollateral(
-        uint256 initialDeposit,
-        uint256 resultingCollateralMultiplier,
-        uint104 rate
-    )
-        external
-    {
-        rate = uint104(bound(rate, 1e27, 10e27));
-        ionPool.setRate(ilkIndex, rate);
-        super.testForkFuzz_FlashLoanCollateral(initialDeposit, resultingCollateralMultiplier);
-    }
-
-    function testForkFuzz_WithRateChange_FlashLoanWeth(
-        uint256 initialDeposit,
-        uint256 resultingCollateralMultiplier,
-        uint104 rate
-    )
-        external
-    {
-        rate = uint104(bound(rate, 1e27, 10e27));
-        ionPool.setRate(ilkIndex, rate);
-        super.testForkFuzz_FlashLoanWeth(initialDeposit, resultingCollateralMultiplier);
-    }
-
-    function testForkFuzz_WithRateChange_FlashSwapLeverage(
-        uint256 initialDeposit,
-        uint256 resultingCollateralMultiplier,
-        uint104 rate
-    )
-        external
-    {
-        rate = uint104(bound(rate, 1e27, 10e27));
-        ionPool.setRate(ilkIndex, rate);
-        super.testForkFuzz_FlashSwapLeverage(initialDeposit, resultingCollateralMultiplier);
-    }
-
-    function testForkFuzz_WithRateChange_FlashSwapDeleverage(
-        uint256 initialDeposit,
-        uint256 resultingCollateralMultiplier,
-        uint104 rate
-    )
-        external
-    {
-        rate = uint104(bound(rate, 1e27, 10e27));
-        ionPool.setRate(ilkIndex, rate);
-        super.testForkFuzz_FlashSwapDeleverage(initialDeposit, resultingCollateralMultiplier);
+contract SwEthHandler_WithRateChange_ForkFuzzTest is
+    SwEthHandler_ForkBase,
+    BalancerFlashloanDirectMintHandler_WithRateChange_FuzzTest,
+    UniswapFlashswapHandler_WithRateChange_FuzzTest
+{
+    function setUp() public virtual override(IonHandler_ForkBase, SwEthHandler_ForkBase) {
+        super.setUp();
+        ufConfig.initialDepositLowerBound = 1e13;
+        bfdmConfig.initialDepositLowerBound = 4 wei;
     }
 }

--- a/test/fork/fuzz/WstEthHandlerForkFuzz.t.sol
+++ b/test/fork/fuzz/WstEthHandlerForkFuzz.t.sol
@@ -6,7 +6,7 @@ import { IonHandler_ForkBase } from "../../helpers/IonHandlerForkBase.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import { WadRayMath, WAD, RAY } from "../../../src/libraries/math/WadRayMath.sol";
+import { WadRayMath, RAY } from "../../../src/libraries/math/WadRayMath.sol";
 import { IWstEth } from "../../../src/interfaces/ProviderInterfaces.sol";
 import { LidoLibrary } from "../../../src/libraries/LidoLibrary.sol";
 import {
@@ -17,8 +17,6 @@ import {
     UniswapFlashswapHandler_FuzzTest,
     UniswapFlashswapHandler_WithRateChange_FuzzTest
 } from "./handlers-base/UniswapFlashswapHandler.t.sol";
-
-import { Vm } from "forge-std/Vm.sol";
 
 using LidoLibrary for IWstEth;
 

--- a/test/fork/fuzz/WstEthHandlerForkFuzz.t.sol
+++ b/test/fork/fuzz/WstEthHandlerForkFuzz.t.sol
@@ -2,220 +2,33 @@
 pragma solidity 0.8.21;
 
 import { WstEthHandler_ForkBase } from "../../fork/concrete/WstEthHandlerFork.t.sol";
+import { IonHandler_ForkBase } from "../../helpers/IonHandlerForkBase.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { WadRayMath, WAD, RAY } from "../../../src/libraries/math/WadRayMath.sol";
 import { IWstEth } from "../../../src/interfaces/ProviderInterfaces.sol";
 import { LidoLibrary } from "../../../src/libraries/LidoLibrary.sol";
+import {
+    BalancerFlashloanDirectMintHandler_FuzzTest,
+    BalancerFlashloanDirectMintHandler_WithRateChange_FuzzTest
+} from "./handlers-base/BalancerFlashloanDirectMintHandler.t.sol";
+import {
+    UniswapFlashswapHandler_FuzzTest,
+    UniswapFlashswapHandler_WithRateChange_FuzzTest
+} from "./handlers-base/UniswapFlashswapHandler.t.sol";
 
 import { Vm } from "forge-std/Vm.sol";
 
 using LidoLibrary for IWstEth;
 
-abstract contract WstEthHandler_ForkFuzzTest is WstEthHandler_ForkBase {
-    using WadRayMath for *;
-
-    function testForkFuzz_FlashLoanCollateral(uint256 initialDeposit, uint256 resultingCollateralMultiplier) public {
-        initialDeposit = bound(initialDeposit, 4 wei, INITIAL_THIS_UNDERLYING_BALANCE);
-        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
-        uint256 resultingDebt = MAINNET_WSTETH.getEthAmountInForLstAmountOut(resultingCollateral - initialDeposit);
-
-        uint256 ilkRate = ionPool.rate(ilkIndex);
-        uint256 ilkSpot = ionPool.spot(ilkIndex).getSpot();
-        // Calculating this way emulates the newTotalDebt value in IonPool
-        uint256 newTotalDebt = resultingDebt.rayDivUp(ilkRate) * ilkRate;
-
-        bool unsafePositionChange = newTotalDebt > resultingCollateral * ilkSpot;
-
-        vm.assume(!unsafePositionChange);
-
-        weth.approve(address(wstEthHandler), type(uint256).max);
-        ionPool.addOperator(address(wstEthHandler));
-
-        wstEthHandler.flashLeverageCollateral(initialDeposit, resultingCollateral, resultingDebt, new bytes32[](0));
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertLe(
-            ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)),
-            resultingDebt + roundingError + 1,
-            "max resulting debt"
-        );
-        assertEq(IERC20(address(MAINNET_WSTETH)).balanceOf(address(wstEthHandler)), 0);
-        assertLe(weth.balanceOf(address(wstEthHandler)), roundingError);
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-    }
-
-    function testForkFuzz_FlashLoanWeth(uint256 initialDeposit, uint256 resultingCollateralMultiplier) public {
-        initialDeposit = bound(initialDeposit, 4 wei, INITIAL_THIS_UNDERLYING_BALANCE);
-        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
-        uint256 resultingDebt = MAINNET_WSTETH.getEthAmountInForLstAmountOut(resultingCollateral - initialDeposit);
-
-        uint256 ilkRate = ionPool.rate(ilkIndex);
-        uint256 ilkSpot = ionPool.spot(ilkIndex).getSpot();
-        uint256 newTotalDebt = resultingDebt.rayDivUp(ilkRate) * ilkRate;
-
-        bool unsafePositionChange = newTotalDebt > resultingCollateral * ilkSpot;
-
-        weth.approve(address(wstEthHandler), type(uint256).max);
-        ionPool.addOperator(address(wstEthHandler));
-
-        vm.assume(!unsafePositionChange);
-
-        wstEthHandler.flashLeverageWeth(initialDeposit, resultingCollateral, resultingDebt, new bytes32[](0));
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertApproxEqAbs(
-            ionPool.normalizedDebt(ilkIndex, address(this)).rayMulDown(ionPool.rate(ilkIndex)),
-            resultingDebt,
-            ilkRate / RAY
-        );
-        assertEq(IERC20(address(MAINNET_WSTETH)).balanceOf(address(wstEthHandler)), 0);
-        assertLe(weth.balanceOf(address(wstEthHandler)), roundingError);
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-    }
-
-    function testForkFuzz_FlashSwapLeverage(uint256 initialDeposit, uint256 resultingCollateralMultiplier) public {
-        initialDeposit = bound(initialDeposit, 1e13, INITIAL_THIS_UNDERLYING_BALANCE);
-        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
-        uint256 maxResultingDebt = resultingCollateral; // in weth. This is technically subject to slippage but we will
-            // skip protecting for this in the test
-
-        weth.approve(address(wstEthHandler), type(uint256).max);
-        ionPool.addOperator(address(wstEthHandler));
-
-        wstEthHandler.flashswapLeverage(
-            initialDeposit,
-            resultingCollateral,
-            maxResultingDebt,
-            sqrtPriceLimitX96,
-            block.timestamp + 1,
-            new bytes32[](0)
-        );
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-        assertEq(IERC20(address(MAINNET_WSTETH)).balanceOf(address(wstEthHandler)), 0);
-        assertLe(weth.balanceOf(address(wstEthHandler)), roundingError);
-        assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
-    }
-
-    function testForkFuzz_FlashSwapDeleverage(uint256 initialDeposit, uint256 resultingCollateralMultiplier) public {
-        initialDeposit = bound(initialDeposit, 1e13, INITIAL_THIS_UNDERLYING_BALANCE);
-        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
-        uint256 maxResultingDebt = resultingCollateral; // in weth. This is technically subject to slippage but we will
-            // skip protecting for this in the test
-
-        weth.approve(address(wstEthHandler), type(uint256).max);
-        ionPool.addOperator(address(wstEthHandler));
-
-        vm.recordLogs();
-        wstEthHandler.flashswapLeverage(
-            initialDeposit,
-            resultingCollateral,
-            maxResultingDebt,
-            sqrtPriceLimitX96,
-            block.timestamp + 1,
-            new bytes32[](0)
-        );
-
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-
-        uint256 normalizedDebtCreated;
-        for (uint256 i = 0; i < entries.length; i++) {
-            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
-            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
-            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
-        }
-
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-        assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), normalizedDebtCreated);
-
-        vm.warp(block.timestamp + 3 hours);
-
-        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
-        // Want to completely deleverage position and only leave initial capital
-        // in vault
-        uint256 maxCollateralToRemove = (resultingCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
-        // Remove all debt
-        uint256 normalizedDebtToRemove = ionPool.normalizedDebt(ilkIndex, address(this));
-
-        // Round up otherwise can leave 1 wei of dust in debt left
-        uint256 debtToRemove = normalizedDebtToRemove.rayMulUp(ionPool.rate(ilkIndex));
-
-        wstEthHandler.flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0, block.timestamp + 1);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertGe(ionPool.collateral(ilkIndex, address(this)), resultingCollateral - maxCollateralToRemove);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), 0);
-        assertEq(IERC20(address(MAINNET_WSTETH)).balanceOf(address(wstEthHandler)), 0);
-        assertLe(weth.balanceOf(address(wstEthHandler)), roundingError);
-    }
-
-    function testForkFuzz_FlashSwapDeleverageFull(
-        uint256 initialDeposit,
-        uint256 resultingCollateralMultiplier
-    )
-        public
-    {
-        initialDeposit = bound(initialDeposit, 1e13, INITIAL_THIS_UNDERLYING_BALANCE);
-        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
-        uint256 maxResultingDebt = resultingCollateral; // in weth. This is technically subject to slippage but we will
-            // skip protecting for this in the test
-
-        weth.approve(address(wstEthHandler), type(uint256).max);
-        ionPool.addOperator(address(wstEthHandler));
-
-        vm.recordLogs();
-        wstEthHandler.flashswapLeverage(
-            initialDeposit,
-            resultingCollateral,
-            maxResultingDebt,
-            sqrtPriceLimitX96,
-            block.timestamp + 1,
-            new bytes32[](0)
-        );
-
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-
-        uint256 normalizedDebtCreated;
-        for (uint256 i = 0; i < entries.length; i++) {
-            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
-            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
-            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
-        }
-
-        assertEq(ionPool.collateral(ilkIndex, address(this)), resultingCollateral);
-        assertLt(ionPool.normalizedDebt(ilkIndex, address(this)).rayMulUp(ionPool.rate(ilkIndex)), maxResultingDebt);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), normalizedDebtCreated);
-
-        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
-        // Want to completely deleverage position and only leave initial capital
-        // in vault
-        uint256 maxCollateralToRemove = (resultingCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
-        uint256 normalizedDebtCurrent = ionPool.normalizedDebt(ilkIndex, address(this));
-
-        // Remove all debt if any
-        uint256 debtToRemove = normalizedDebtCurrent == 0 ? 0 : type(uint256).max;
-
-        wstEthHandler.flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0, block.timestamp + 1);
-
-        uint256 currentRate = ionPool.rate(ilkIndex);
-        uint256 roundingError = currentRate / RAY;
-
-        assertGe(ionPool.collateral(ilkIndex, address(this)), resultingCollateral - maxCollateralToRemove);
-        assertEq(ionPool.normalizedDebt(ilkIndex, address(this)), 0);
-        assertEq(IERC20(address(MAINNET_WSTETH)).balanceOf(address(wstEthHandler)), 0);
-        assertLe(weth.balanceOf(address(wstEthHandler)), roundingError);
+abstract contract WstEthHandler_ForkFuzzTest is
+    WstEthHandler_ForkBase,
+    BalancerFlashloanDirectMintHandler_FuzzTest,
+    UniswapFlashswapHandler_FuzzTest
+{
+    function setUp() public virtual override(IonHandler_ForkBase, WstEthHandler_ForkBase) {
+        super.setUp();
     }
 }
 
@@ -344,6 +157,7 @@ contract WstEthHandler_ZapForkFuzzTest is WstEthHandler_ForkBase {
 
         uint256 initialStEthDeposit = _mintStEth(initialDeposit);
         uint256 resultingStEthDeposit = initialStEthDeposit * bound(resultingCollateralMultiplier, 1, 5);
+        uint160 sqrtPriceLimitX96 = 0;
 
         uint256 expectedResultingWstEthDeposit =
             IWstEth(address(MAINNET_WSTETH)).getWstETHByStETH(resultingStEthDeposit);
@@ -379,53 +193,15 @@ contract WstEthHandler_ZapForkFuzzTest is WstEthHandler_ForkBase {
     }
 }
 
-contract WstEthHandler_WithRateChange_ForkFuzzTest is WstEthHandler_ForkFuzzTest {
-    function testForkFuzz_WithRateChange_FlashLoanCollateral(
-        uint256 initialDeposit,
-        uint256 resultingCollateralMultiplier,
-        uint104 rate
-    )
-        external
-    {
-        rate = uint104(bound(rate, 1e27, 10e27));
-        ionPool.setRate(ilkIndex, rate);
-        super.testForkFuzz_FlashLoanCollateral(initialDeposit, resultingCollateralMultiplier);
-    }
-
-    function testForkFuzz_WithRateChange_FlashLoanWeth(
-        uint256 initialDeposit,
-        uint256 resultingCollateralMultiplier,
-        uint104 rate
-    )
-        external
-    {
-        rate = uint104(bound(rate, 1e27, 10e27));
-        ionPool.setRate(ilkIndex, rate);
-        super.testForkFuzz_FlashLoanWeth(initialDeposit, resultingCollateralMultiplier);
-    }
-
-    function testForkFuzz_WithRateChange_FlashSwapLeverage(
-        uint256 initialDeposit,
-        uint256 resultingCollateralMultiplier,
-        uint104 rate
-    )
-        external
-    {
-        rate = uint104(bound(rate, 1e27, 10e27));
-        ionPool.setRate(ilkIndex, rate);
-        super.testForkFuzz_FlashSwapLeverage(initialDeposit, resultingCollateralMultiplier);
-    }
-
-    function testForkFuzz_WithRateChange_FlashSwapDeleverage(
-        uint256 initialDeposit,
-        uint256 resultingCollateralMultiplier,
-        uint104 rate
-    )
-        external
-    {
-        rate = uint104(bound(rate, 1e27, 10e27));
-        ionPool.setRate(ilkIndex, rate);
-        super.testForkFuzz_FlashSwapDeleverage(initialDeposit, resultingCollateralMultiplier);
+contract WstEthHandler_WithRateChange_ForkFuzzTest is
+    WstEthHandler_ForkBase,
+    BalancerFlashloanDirectMintHandler_WithRateChange_FuzzTest,
+    UniswapFlashswapHandler_WithRateChange_FuzzTest
+{
+    function setUp() public virtual override(IonHandler_ForkBase, WstEthHandler_ForkBase) {
+        super.setUp();
+        ufConfig.initialDepositLowerBound = 1e13;
+        bfdmConfig.initialDepositLowerBound = 4 wei;
     }
 }
 

--- a/test/fork/fuzz/handlers-base/BalancerFlashloanDirectMintHandler.t.sol
+++ b/test/fork/fuzz/handlers-base/BalancerFlashloanDirectMintHandler.t.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import { IonHandler_ForkBase } from "../../../helpers/IonHandlerForkBase.sol";
+import { WadRayMath, RAY } from "../../../../src/libraries/math/WadRayMath.sol";
+import {
+    BalancerFlashloanDirectMintHandler,
+    VAULT
+} from "../../../../src/flash/handlers/base/BalancerFlashloanDirectMintHandler.sol";
+
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+
+import { IFlashLoanRecipient } from "@balancer-labs/v2-interfaces/contracts/vault/IFlashLoanRecipient.sol";
+import { IERC20 as IERC20Balancer } from "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
+
+import { console2 } from "forge-std/console2.sol";
+
+using WadRayMath for uint256;
+
+struct Config {
+    uint256 initialDepositLowerBound;
+}
+
+abstract contract BalancerFlashloanDirectMintHandler_FuzzTest is IonHandler_ForkBase {
+    Config bfdmConfig;
+
+    function testForkFuzz_FlashLoanCollateral(uint256 initialDeposit, uint256 resultingCollateralMultiplier) public {
+        initialDeposit = bound(initialDeposit, bfdmConfig.initialDepositLowerBound, INITIAL_THIS_UNDERLYING_BALANCE);
+        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
+        uint256 resultingDebt =
+            _getProviderLibrary().getEthAmountInForLstAmountOut(resultingCollateral - initialDeposit);
+
+        uint256 ilkRate = ionPool.rate(_getIlkIndex());
+        uint256 ilkSpot = ionPool.spot(_getIlkIndex()).getSpot();
+        // Calculating this way emulates the newTotalDebt value in IonPool
+        uint256 newTotalDebt = resultingDebt.rayDivUp(ilkRate) * ilkRate;
+
+        bool unsafePositionChange = newTotalDebt > resultingCollateral * ilkSpot;
+
+        vm.assume(!unsafePositionChange);
+
+        weth.approve(address(_getTypedBFDMHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedBFDMHandler()));
+
+        _getTypedBFDMHandler().flashLeverageCollateral(
+            initialDeposit, resultingCollateral, resultingDebt, new bytes32[](0)
+        );
+
+        uint256 currentRate = ionPool.rate(_getIlkIndex());
+        uint256 roundingError = currentRate / RAY;
+
+        assertGe(
+            ionPool.normalizedDebt(_getIlkIndex(), address(this)).rayMulUp(ionPool.rate(_getIlkIndex())), resultingDebt
+        );
+        assertEq(IERC20(address(_getCollaterals()[_getIlkIndex()])).balanceOf(address(_getTypedBFDMHandler())), 0);
+        assertLe(weth.balanceOf(address(_getTypedBFDMHandler())), roundingError);
+        assertEq(ionPool.collateral(_getIlkIndex(), address(this)), resultingCollateral);
+    }
+
+    function testForkFuzz_FlashLoanWeth(uint256 initialDeposit, uint256 resultingCollateralMultiplier) public {
+        initialDeposit = bound(initialDeposit, bfdmConfig.initialDepositLowerBound, INITIAL_THIS_UNDERLYING_BALANCE);
+        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
+        uint256 resultingDebt =
+            _getProviderLibrary().getEthAmountInForLstAmountOut(resultingCollateral - initialDeposit);
+
+        uint256 ilkRate = ionPool.rate(_getIlkIndex());
+        uint256 ilkSpot = ionPool.spot(_getIlkIndex()).getSpot();
+        uint256 newTotalDebt = resultingDebt.rayDivUp(ilkRate) * ilkRate;
+
+        bool unsafePositionChange = newTotalDebt > resultingCollateral * ilkSpot;
+
+        weth.approve(address(_getTypedBFDMHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedBFDMHandler()));
+
+        vm.assume(!unsafePositionChange);
+
+        _getTypedBFDMHandler().flashLeverageWeth(initialDeposit, resultingCollateral, resultingDebt, new bytes32[](0));
+
+        uint256 currentRate = ionPool.rate(_getIlkIndex());
+        uint256 roundingError = currentRate / RAY;
+
+        assertApproxEqAbs(
+            ionPool.normalizedDebt(_getIlkIndex(), address(this)).rayMulDown(ionPool.rate(_getIlkIndex())),
+            resultingDebt,
+            ilkRate / RAY
+        );
+        assertEq(IERC20(address(_getCollaterals()[_getIlkIndex()])).balanceOf(address(_getTypedBFDMHandler())), 0);
+        assertLe(weth.balanceOf(address(_getTypedBFDMHandler())), roundingError);
+        assertEq(ionPool.collateral(_getIlkIndex(), address(this)), resultingCollateral);
+    }
+
+    function _getTypedBFDMHandler() private view returns (BalancerFlashloanDirectMintHandler) {
+        return BalancerFlashloanDirectMintHandler(payable(_getHandler()));
+    }
+}
+
+abstract contract BalancerFlashloanDirectMintHandler_WithRateChange_FuzzTest is
+    BalancerFlashloanDirectMintHandler_FuzzTest
+{
+    function testForkFuzz_WithRateChange_FlashLoanCollateral(
+        uint256 initialDeposit,
+        uint256 resultingCollateralMultiplier,
+        uint104 rate
+    )
+        external
+    {
+        rate = uint104(bound(rate, 1e27, 10e27));
+        ionPool.setRate(_getIlkIndex(), rate);
+        super.testForkFuzz_FlashLoanCollateral(initialDeposit, resultingCollateralMultiplier);
+    }
+
+    function testForkFuzz_WithRateChange_FlashLoanWeth(
+        uint256 initialDeposit,
+        uint256 resultingCollateralMultiplier,
+        uint104 rate
+    )
+        external
+    {
+        rate = uint104(bound(rate, 1e27, 10e27));
+        ionPool.setRate(_getIlkIndex(), rate);
+        super.testForkFuzz_FlashLoanWeth(initialDeposit, resultingCollateralMultiplier);
+    }
+}

--- a/test/fork/fuzz/handlers-base/BalancerFlashloanDirectMintHandler.t.sol
+++ b/test/fork/fuzz/handlers-base/BalancerFlashloanDirectMintHandler.t.sol
@@ -4,16 +4,10 @@ pragma solidity 0.8.21;
 import { IonHandler_ForkBase } from "../../../helpers/IonHandlerForkBase.sol";
 import { WadRayMath, RAY } from "../../../../src/libraries/math/WadRayMath.sol";
 import {
-    BalancerFlashloanDirectMintHandler,
-    VAULT
+    BalancerFlashloanDirectMintHandler
 } from "../../../../src/flash/handlers/base/BalancerFlashloanDirectMintHandler.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
-
-import { IFlashLoanRecipient } from "@balancer-labs/v2-interfaces/contracts/vault/IFlashLoanRecipient.sol";
-import { IERC20 as IERC20Balancer } from "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
-
-import { console2 } from "forge-std/console2.sol";
 
 using WadRayMath for uint256;
 

--- a/test/fork/fuzz/handlers-base/UniswapFlashloanBalancerSwapHandler.t.sol
+++ b/test/fork/fuzz/handlers-base/UniswapFlashloanBalancerSwapHandler.t.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import { IonHandler_ForkBase } from "../../../helpers/IonHandlerForkBase.sol";
+import { WadRayMath, RAY, WAD } from "../../../../src/libraries/math/WadRayMath.sol";
+import { UniswapFlashloanBalancerSwapHandler } from
+    "../../../../src/flash/handlers/base/UniswapFlashloanBalancerSwapHandler.sol";
+import { IonHandlerBase } from "../../../../src/flash/handlers/base/IonHandlerBase.sol";
+
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+
+import { Vm } from "forge-std/Vm.sol";
+import { console2 } from "forge-std/console2.sol";
+
+using WadRayMath for uint256;
+
+struct Config {
+    uint256 initialDepositLowerBound;
+}
+
+abstract contract UniswapFlashloanBalancerSwapHandler_FuzzTest is IonHandler_ForkBase {
+    Config ufbsConfig;
+
+    function testForkFuzz_flashLeverageWethAndSwap(
+        uint256 initialDeposit,
+        uint256 resultingCollateralMultiplier
+    )
+        public
+    {
+        initialDeposit = bound(initialDeposit, ufbsConfig.initialDepositLowerBound, INITIAL_THIS_UNDERLYING_BALANCE);
+        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
+        uint256 maxResultingDebt = resultingCollateral; // in weth. This is technically subject to slippage but we will
+            // skip protecting for this in the test
+
+        weth.approve(address(_getTypedUFBSHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedUFBSHandler()));
+
+        _getTypedUFBSHandler().flashLeverageWethAndSwap(
+            initialDeposit, resultingCollateral, maxResultingDebt, block.timestamp + 1, new bytes32[](0)
+        );
+
+        uint256 currentRate = ionPool.rate(_getIlkIndex());
+        uint256 roundingError = currentRate / RAY;
+
+        assertEq(ionPool.collateral(_getIlkIndex(), address(this)), resultingCollateral);
+        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(_getTypedUFBSHandler())), 0);
+        assertLe(weth.balanceOf(address(_getTypedUFBSHandler())), roundingError);
+        assertLt(
+            ionPool.normalizedDebt(_getIlkIndex(), address(this)).rayMulUp(ionPool.rate(_getIlkIndex())),
+            maxResultingDebt
+        );
+    }
+
+    function testForkFuzz_flashDeleverageWethAndSwap(
+        uint256 initialDeposit,
+        uint256 resultingCollateralMultiplier
+    )
+        public
+    {
+        initialDeposit = bound(initialDeposit, ufbsConfig.initialDepositLowerBound, INITIAL_THIS_UNDERLYING_BALANCE);
+        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
+        uint256 maxResultingDebt = resultingCollateral; // in weth. This is technically subject to slippage but we will
+            // skip protecting for this in the test
+
+        weth.approve(address(_getTypedUFBSHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedUFBSHandler()));
+
+        vm.recordLogs();
+        _getTypedUFBSHandler().flashLeverageWethAndSwap(
+            initialDeposit, resultingCollateral, maxResultingDebt, block.timestamp + 1, new bytes32[](0)
+        );
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        uint256 normalizedDebtCreated;
+        for (uint256 i = 0; i < entries.length; i++) {
+            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
+            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
+            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
+        }
+
+        assertEq(ionPool.collateral(_getIlkIndex(), address(this)), resultingCollateral);
+        assertLt(
+            ionPool.normalizedDebt(_getIlkIndex(), address(this)).rayMulUp(ionPool.rate(_getIlkIndex())),
+            maxResultingDebt
+        );
+        assertEq(ionPool.normalizedDebt(_getIlkIndex(), address(this)), normalizedDebtCreated);
+
+        vm.warp(block.timestamp + 3 hours);
+
+        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
+        // Want to completely deleverage position and only leave initial capital
+        // in vault
+        uint256 maxCollateralToRemove = (resultingCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
+        // Remove all debt
+        uint256 normalizedDebtToRemove = ionPool.normalizedDebt(_getIlkIndex(), address(this));
+
+        // Round up otherwise can leave 1 wei of dust in debt left
+        uint256 debtToRemove = normalizedDebtToRemove.rayMulUp(ionPool.rate(_getIlkIndex()));
+
+        _getTypedUFBSHandler().flashDeleverageWethAndSwap(maxCollateralToRemove, debtToRemove, block.timestamp + 1);
+
+        uint256 currentRate = ionPool.rate(_getIlkIndex());
+        uint256 roundingError = currentRate / RAY;
+
+        assertGe(ionPool.collateral(_getIlkIndex(), address(this)), resultingCollateral - maxCollateralToRemove);
+        assertEq(ionPool.normalizedDebt(_getIlkIndex(), address(this)), 0);
+        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(_getTypedUFBSHandler())), 0);
+        assertLe(weth.balanceOf(address(_getTypedUFBSHandler())), roundingError);
+    }
+
+    function testForkFuzz_flashDeleverageWethAndSwapFull(
+        uint256 initialDeposit,
+        uint256 resultingCollateralMultiplier
+    )
+        public
+    {
+        initialDeposit = bound(initialDeposit, ufbsConfig.initialDepositLowerBound, INITIAL_THIS_UNDERLYING_BALANCE);
+        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
+        uint256 maxResultingDebt = resultingCollateral; // in weth. This is technically subject to slippage but we will
+            // skip protecting for this in the test
+
+        weth.approve(address(_getTypedUFBSHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedUFBSHandler()));
+
+        vm.recordLogs();
+        _getTypedUFBSHandler().flashLeverageWethAndSwap(
+            initialDeposit, resultingCollateral, maxResultingDebt, block.timestamp + 1, new bytes32[](0)
+        );
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        uint256 normalizedDebtCreated;
+        for (uint256 i = 0; i < entries.length; i++) {
+            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
+            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
+            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
+        }
+
+        assertEq(ionPool.collateral(_getIlkIndex(), address(this)), resultingCollateral);
+        assertLt(
+            ionPool.normalizedDebt(_getIlkIndex(), address(this)).rayMulUp(ionPool.rate(_getIlkIndex())),
+            maxResultingDebt
+        );
+        assertEq(ionPool.normalizedDebt(_getIlkIndex(), address(this)), normalizedDebtCreated);
+
+        vm.warp(block.timestamp + 3 hours);
+
+        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
+        // Want to completely deleverage position and only leave initial capital
+        // in vault
+        uint256 maxCollateralToRemove = (resultingCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
+        // Remove all debt
+        uint256 debtToRemove = type(uint256).max;
+
+        _getTypedUFBSHandler().flashDeleverageWethAndSwap(maxCollateralToRemove, debtToRemove, block.timestamp + 1);
+
+        uint256 currentRate = ionPool.rate(_getIlkIndex());
+        uint256 roundingError = currentRate / RAY;
+
+        assertGe(ionPool.collateral(_getIlkIndex(), address(this)), resultingCollateral - maxCollateralToRemove);
+        assertEq(ionPool.normalizedDebt(_getIlkIndex(), address(this)), 0);
+        assertEq(IERC20(address(MAINNET_ETHX)).balanceOf(address(_getTypedUFBSHandler())), 0);
+        assertLe(weth.balanceOf(address(_getTypedUFBSHandler())), roundingError);
+    }
+
+    function _getTypedUFBSHandler() internal view returns (UniswapFlashloanBalancerSwapHandler) {
+        return UniswapFlashloanBalancerSwapHandler(payable(_getHandler()));
+    }
+}
+
+abstract contract UniswapFlashloanBalancerSwapHandler_WithRateChange_FuzzTest is
+    UniswapFlashloanBalancerSwapHandler_FuzzTest
+{
+    function testForkFuzz_WithRateChange_flashLeverageWethAndSwap(
+        uint256 initialDeposit,
+        uint256 resultingCollateralMultiplier,
+        uint104 rate
+    )
+        external
+    {
+        rate = uint104(bound(rate, 1e27, 10e27));
+        ionPool.setRate(_getIlkIndex(), rate);
+        super.testForkFuzz_flashLeverageWethAndSwap(initialDeposit, resultingCollateralMultiplier);
+    }
+
+    function testForkFuzz_WithRateChange_flashDeleverageWethAndSwap(
+        uint256 initialDeposit,
+        uint256 resultingCollateralMultiplier,
+        uint104 rate
+    )
+        external
+    {
+        rate = uint104(bound(rate, 1e27, 10e27));
+        ionPool.setRate(_getIlkIndex(), rate);
+        super.testForkFuzz_flashDeleverageWethAndSwap(initialDeposit, resultingCollateralMultiplier);
+    }
+
+    function testForkFuzz_WithRateChange_flashDeleverageWethAndSwapFull(
+        uint256 initialDeposit,
+        uint256 resultingCollateralMultiplier,
+        uint104 rate
+    )
+        external
+    {
+        rate = uint104(bound(rate, 1e27, 10e27));
+        ionPool.setRate(_getIlkIndex(), rate);
+        super.testForkFuzz_flashDeleverageWethAndSwapFull(initialDeposit, resultingCollateralMultiplier);
+    }
+}

--- a/test/fork/fuzz/handlers-base/UniswapFlashloanBalancerSwapHandler.t.sol
+++ b/test/fork/fuzz/handlers-base/UniswapFlashloanBalancerSwapHandler.t.sol
@@ -5,12 +5,10 @@ import { IonHandler_ForkBase } from "../../../helpers/IonHandlerForkBase.sol";
 import { WadRayMath, RAY, WAD } from "../../../../src/libraries/math/WadRayMath.sol";
 import { UniswapFlashloanBalancerSwapHandler } from
     "../../../../src/flash/handlers/base/UniswapFlashloanBalancerSwapHandler.sol";
-import { IonHandlerBase } from "../../../../src/flash/handlers/base/IonHandlerBase.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 
 import { Vm } from "forge-std/Vm.sol";
-import { console2 } from "forge-std/console2.sol";
 
 using WadRayMath for uint256;
 

--- a/test/fork/fuzz/handlers-base/UniswapFlashswapHandler.t.sol
+++ b/test/fork/fuzz/handlers-base/UniswapFlashswapHandler.t.sol
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import { IonHandler_ForkBase } from "../../../helpers/IonHandlerForkBase.sol";
+import { WadRayMath, RAY, WAD } from "../../../../src/libraries/math/WadRayMath.sol";
+import { UniswapFlashswapHandler } from "../../../../src/flash/handlers/base/UniswapFlashswapHandler.sol";
+import { IonHandlerBase } from "../../../../src/flash/handlers/base/IonHandlerBase.sol";
+
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+
+import { IFlashLoanRecipient } from "@balancer-labs/v2-interfaces/contracts/vault/IFlashLoanRecipient.sol";
+import { IERC20 as IERC20Balancer } from "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
+
+import { Vm } from "forge-std/Vm.sol";
+import { console2 } from "forge-std/console2.sol";
+
+using WadRayMath for uint256;
+
+struct Config {
+    uint256 initialDepositLowerBound;
+}
+
+abstract contract UniswapFlashswapHandler_FuzzTest is IonHandler_ForkBase {
+    uint160 sqrtPriceLimitX96;
+    Config ufConfig;
+
+    function testForkFuzz_FlashswapLeverage(uint256 initialDeposit, uint256 resultingCollateralMultiplier) public {
+        initialDeposit = bound(initialDeposit, ufConfig.initialDepositLowerBound, INITIAL_THIS_UNDERLYING_BALANCE);
+        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
+        uint256 maxResultingDebt = resultingCollateral; // in weth. This is technically subject to slippage but we will
+            // skip protecting for this in the test
+
+        weth.approve(address(_getTypedUFHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedUFHandler()));
+
+        _getTypedUFHandler().flashswapLeverage(
+            initialDeposit,
+            resultingCollateral,
+            maxResultingDebt,
+            sqrtPriceLimitX96,
+            block.timestamp + 1,
+            new bytes32[](0)
+        );
+
+        uint256 currentRate = ionPool.rate(_getIlkIndex());
+        uint256 roundingError = currentRate / RAY;
+
+        assertEq(ionPool.collateral(_getIlkIndex(), address(this)), resultingCollateral);
+        assertEq(IERC20(address(_getCollaterals()[_getIlkIndex()])).balanceOf(address(_getTypedUFHandler())), 0);
+        assertLe(weth.balanceOf(address(_getTypedUFHandler())), roundingError);
+        assertLt(
+            ionPool.normalizedDebt(_getIlkIndex(), address(this)).rayMulUp(ionPool.rate(_getIlkIndex())),
+            maxResultingDebt
+        );
+    }
+
+    function testForkFuzz_FlashswapDeleverage(uint256 initialDeposit, uint256 resultingCollateralMultiplier) public {
+        initialDeposit = bound(initialDeposit, ufConfig.initialDepositLowerBound, INITIAL_THIS_UNDERLYING_BALANCE);
+        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
+        uint256 maxResultingDebt = resultingCollateral; // in weth. This is technically subject to slippage but we will
+            // skip protecting for this in the test
+
+        weth.approve(address(_getTypedUFHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedUFHandler()));
+
+        vm.recordLogs();
+        _getTypedUFHandler().flashswapLeverage(
+            initialDeposit,
+            resultingCollateral,
+            maxResultingDebt,
+            sqrtPriceLimitX96,
+            block.timestamp + 1,
+            new bytes32[](0)
+        );
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        uint256 normalizedDebtCreated;
+        for (uint256 i = 0; i < entries.length; i++) {
+            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
+            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
+            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
+        }
+
+        assertEq(ionPool.collateral(_getIlkIndex(), address(this)), resultingCollateral);
+        assertLt(
+            ionPool.normalizedDebt(_getIlkIndex(), address(this)).rayMulUp(ionPool.rate(_getIlkIndex())),
+            maxResultingDebt
+        );
+        assertEq(ionPool.normalizedDebt(_getIlkIndex(), address(this)), normalizedDebtCreated);
+
+        vm.warp(block.timestamp + 3 hours);
+
+        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
+        // Want to completely deleverage position and only leave initial capital
+        // in vault
+        uint256 maxCollateralToRemove = (resultingCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
+        // Remove all debt
+        uint256 normalizedDebtToRemove = ionPool.normalizedDebt(_getIlkIndex(), address(this));
+
+        // Round up otherwise can leave 1 wei of dust in debt left
+        uint256 debtToRemove = normalizedDebtToRemove.rayMulUp(ionPool.rate(_getIlkIndex()));
+
+        _getTypedUFHandler().flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0, block.timestamp + 1);
+
+        uint256 currentRate = ionPool.rate(_getIlkIndex());
+        uint256 roundingError = currentRate / RAY;
+
+        assertGe(ionPool.collateral(_getIlkIndex(), address(this)), resultingCollateral - maxCollateralToRemove);
+        assertEq(ionPool.normalizedDebt(_getIlkIndex(), address(this)), 0);
+        assertEq(IERC20(address(_getCollaterals()[_getIlkIndex()])).balanceOf(address(_getTypedUFHandler())), 0);
+        assertLe(weth.balanceOf(address(_getTypedUFHandler())), roundingError);
+    }
+
+    function testForkFuzz_FlashswapDeleverageFull(
+        uint256 initialDeposit,
+        uint256 resultingCollateralMultiplier
+    )
+        public
+    {
+        initialDeposit = bound(initialDeposit, ufConfig.initialDepositLowerBound, INITIAL_THIS_UNDERLYING_BALANCE);
+        uint256 resultingCollateral = initialDeposit * bound(resultingCollateralMultiplier, 1, 5);
+        uint256 maxResultingDebt = resultingCollateral; // in weth. This is technically subject to slippage but we will
+            // skip protecting for this in the test
+
+        weth.approve(address(_getTypedUFHandler()), type(uint256).max);
+        ionPool.addOperator(address(_getTypedUFHandler()));
+
+        vm.recordLogs();
+        _getTypedUFHandler().flashswapLeverage(
+            initialDeposit,
+            resultingCollateral,
+            maxResultingDebt,
+            sqrtPriceLimitX96,
+            block.timestamp + 1,
+            new bytes32[](0)
+        );
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        uint256 normalizedDebtCreated;
+        for (uint256 i = 0; i < entries.length; i++) {
+            // keccak256("Borrow(uint8,address,address,uint256,uint256,uint256)")
+            if (entries[i].topics[0] != 0xe3e92e977f830d2a0b92c58e8866694b5dc929a35e2b95846f427de0f0bb412f) continue;
+            normalizedDebtCreated = abi.decode(entries[i].data, (uint256));
+        }
+
+        assertEq(ionPool.collateral(_getIlkIndex(), address(this)), resultingCollateral);
+        assertLt(
+            ionPool.normalizedDebt(_getIlkIndex(), address(this)).rayMulUp(ionPool.rate(_getIlkIndex())),
+            maxResultingDebt
+        );
+        assertEq(ionPool.normalizedDebt(_getIlkIndex(), address(this)), normalizedDebtCreated);
+
+        uint256 slippageAndFeeTolerance = 1.005e18; // 0.5%
+        // Want to completely deleverage position and only leave initial capital
+        // in vault
+        uint256 maxCollateralToRemove = (resultingCollateral - initialDeposit) * slippageAndFeeTolerance / WAD;
+        uint256 normalizedDebtCurrent = ionPool.normalizedDebt(_getIlkIndex(), address(this));
+
+        // Remove all debt if any
+        uint256 debtToRemove = normalizedDebtCurrent == 0 ? 0 : type(uint256).max;
+
+        _getTypedUFHandler().flashswapDeleverage(maxCollateralToRemove, debtToRemove, 0, block.timestamp + 1);
+
+        uint256 currentRate = ionPool.rate(_getIlkIndex());
+        uint256 roundingError = currentRate / RAY;
+
+        assertGe(ionPool.collateral(_getIlkIndex(), address(this)), resultingCollateral - maxCollateralToRemove);
+        assertEq(ionPool.normalizedDebt(_getIlkIndex(), address(this)), 0);
+        assertEq(IERC20(address(_getCollaterals()[_getIlkIndex()])).balanceOf(address(_getTypedUFHandler())), 0);
+        assertLe(weth.balanceOf(address(_getTypedUFHandler())), roundingError);
+    }
+
+    function _getTypedUFHandler() private view returns (UniswapFlashswapHandler) {
+        return UniswapFlashswapHandler(payable(_getHandler()));
+    }
+}
+
+abstract contract UniswapFlashswapHandler_WithRateChange_FuzzTest is UniswapFlashswapHandler_FuzzTest {
+    function testForkFuzz_WithRateChange_FlashswapLeverage(
+        uint256 initialDeposit,
+        uint256 resultingCollateralMultiplier,
+        uint104 rate
+    )
+        external
+    {
+        rate = uint104(bound(rate, 1e27, 10e27));
+        ionPool.setRate(_getIlkIndex(), rate);
+        super.testForkFuzz_FlashswapLeverage(initialDeposit, resultingCollateralMultiplier);
+    }
+
+    function testForkFuzz_WithRateChange_FlashswapDeleverage(
+        uint256 initialDeposit,
+        uint256 resultingCollateralMultiplier,
+        uint104 rate
+    )
+        external
+    {
+        rate = uint104(bound(rate, 1e27, 10e27));
+        ionPool.setRate(_getIlkIndex(), rate);
+        super.testForkFuzz_FlashswapDeleverage(initialDeposit, resultingCollateralMultiplier);
+    }
+
+    function testForkFuzz_WithRateChange_FlashswapDeleverageFull(
+        uint256 initialDeposit,
+        uint256 resultingCollateralMultiplier,
+        uint104 rate
+    )
+        external
+    {
+        rate = uint104(bound(rate, 1e27, 10e27));
+        ionPool.setRate(_getIlkIndex(), rate);
+        super.testForkFuzz_FlashswapDeleverageFull(initialDeposit, resultingCollateralMultiplier);
+    }
+}

--- a/test/fork/fuzz/handlers-base/UniswapFlashswapHandler.t.sol
+++ b/test/fork/fuzz/handlers-base/UniswapFlashswapHandler.t.sol
@@ -4,15 +4,10 @@ pragma solidity 0.8.21;
 import { IonHandler_ForkBase } from "../../../helpers/IonHandlerForkBase.sol";
 import { WadRayMath, RAY, WAD } from "../../../../src/libraries/math/WadRayMath.sol";
 import { UniswapFlashswapHandler } from "../../../../src/flash/handlers/base/UniswapFlashswapHandler.sol";
-import { IonHandlerBase } from "../../../../src/flash/handlers/base/IonHandlerBase.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 
-import { IFlashLoanRecipient } from "@balancer-labs/v2-interfaces/contracts/vault/IFlashLoanRecipient.sol";
-import { IERC20 as IERC20Balancer } from "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
-
 import { Vm } from "forge-std/Vm.sol";
-import { console2 } from "forge-std/console2.sol";
 
 using WadRayMath for uint256;
 

--- a/test/helpers/ERC20PresetMinterPauser.sol
+++ b/test/helpers/ERC20PresetMinterPauser.sol
@@ -9,8 +9,6 @@ import { ERC20Pausable } from "@openzeppelin/contracts/token/ERC20/extensions/ER
 import { AccessControlEnumerable } from "@openzeppelin/contracts/access/extensions/AccessControlEnumerable.sol";
 import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 
-import "forge-std/console.sol";
-
 /**
  * @dev {ERC20} token, including:
  *

--- a/test/helpers/IProviderLibraryExposed.sol
+++ b/test/helpers/IProviderLibraryExposed.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+interface IProviderLibraryExposed {
+    function getEthAmountInForLstAmountOut(uint256 lstAmount) external view returns (uint256);
+
+    function getLstAmountOutForEthAmountIn(uint256 ethAmount) external view returns (uint256);
+}

--- a/test/helpers/IonHandlerForkBase.sol
+++ b/test/helpers/IonHandlerForkBase.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
-import { WAD } from "src/libraries/math/WadRayMath.sol";
-import { IWstEth, IStaderStakePoolsManager, ISwEth, IStEth } from "src/interfaces/ProviderInterfaces.sol";
-import { IWETH9 } from "src/interfaces/IWETH9.sol";
+import { WAD } from "../../src/libraries/math/WadRayMath.sol";
+import { IWstEth, IStaderStakePoolsManager, ISwEth, IStEth } from "../../src/interfaces/ProviderInterfaces.sol";
+import { IWETH9 } from "../../src/interfaces/IWETH9.sol";
 
 import { AggregatorV2V3Interface } from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV2V3Interface.sol";
 

--- a/test/helpers/IonHandlerForkBase.sol
+++ b/test/helpers/IonHandlerForkBase.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.21;
 import { WAD } from "../../src/libraries/math/WadRayMath.sol";
 import { IWstEth, IStaderStakePoolsManager, ISwEth, IStEth } from "../../src/interfaces/ProviderInterfaces.sol";
 import { IWETH9 } from "../../src/interfaces/IWETH9.sol";
+import { IProviderLibraryExposed } from "../helpers/IProviderLibraryExposed.sol";
 
 import { AggregatorV2V3Interface } from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV2V3Interface.sol";
 
@@ -56,8 +57,11 @@ abstract contract IonHandler_ForkBase is IonPoolSharedSetup {
     IWETH9 constant weth = IWETH9(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
 
     IUniswapV3Pool constant WSTETH_WETH_POOL = IUniswapV3Pool(0x109830a1AAaD605BbF02a9dFA7B0B92EC2FB7dAa);
+    IUniswapV3Pool constant ETHX_WETH_POOL = IUniswapV3Pool(0x1b9669b12959Ad51B01FaBcF01EaBDFADB82f578);
 
     uint256 forkBlock = 0;
+
+    bytes32[] borrowerWhitelistProof;
 
     function setUp() public virtual override {
         if (forkBlock == 0) vm.createSelectFork(vm.envString("MAINNET_ARCHIVE_RPC_URL"));
@@ -127,6 +131,19 @@ abstract contract IonHandler_ForkBase is IonPoolSharedSetup {
     function _getDebtCeiling(uint8) internal pure override returns (uint256) {
         return type(uint256).max;
     }
+
+    function _getUniswapPools() internal pure returns (address[] memory uniswapPools) {
+        uniswapPools = new address[](3);
+        uniswapPools[0] = address(WSTETH_WETH_POOL);
+        uniswapPools[1] = address(ETHX_WETH_POOL);
+        uniswapPools[2] = address(SWETH_ETH_POOL);
+    }
+
+    function _getIlkIndex() internal view virtual returns (uint8);
+
+    function _getProviderLibrary() internal view virtual returns (IProviderLibraryExposed);
+
+    function _getHandler() internal view virtual returns (address);
 
     receive() external payable { }
 }

--- a/test/helpers/IonPoolSharedSetup.sol
+++ b/test/helpers/IonPoolSharedSetup.sol
@@ -6,7 +6,7 @@ import { IonRegistry } from "../../src/periphery/IonRegistry.sol";
 import { InterestRate, IlkData, SECONDS_IN_A_YEAR } from "../../src/InterestRate.sol";
 import { IYieldOracle } from "../../src/interfaces/IYieldOracle.sol";
 import { GemJoin } from "../../src/join/GemJoin.sol";
-import { WadRayMath, WAD, RAY } from "../../src/libraries/math/WadRayMath.sol";
+import { WadRayMath, WAD } from "../../src/libraries/math/WadRayMath.sol";
 import { Whitelist } from "../../src/Whitelist.sol";
 import { SpotOracle } from "../../src/oracles/spot/SpotOracle.sol";
 import { BaseTestSetup } from "../helpers/BaseTestSetup.sol";

--- a/test/helpers/ReserveOracleSharedSetup.sol
+++ b/test/helpers/ReserveOracleSharedSetup.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.21;
 
 import { WadRayMath } from "../../src/libraries/math/WadRayMath.sol";
 import { IWstEth, IStaderStakePoolsManager } from "../../src/interfaces/ProviderInterfaces.sol";
-import { ReserveFeed } from "../../src/oracles/reserve/ReserveFeed.sol";
 
 import { ERC20PresetMinterPauser } from "../helpers/ERC20PresetMinterPauser.sol";
 import { IonPoolSharedSetup } from "../helpers/IonPoolSharedSetup.sol";

--- a/test/invariant/IonPool/ActorManager.t.sol
+++ b/test/invariant/IonPool/ActorManager.t.sol
@@ -10,8 +10,6 @@ import { InvariantHelpers } from "../../helpers/InvariantHelpers.sol";
 
 import { LenderHandler, BorrowerHandler, LiquidatorHandler } from "./Handlers.t.sol";
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
 import { CommonBase } from "forge-std/Base.sol";
 import { StdCheats } from "forge-std/StdCheats.sol";
 import { StdUtils } from "forge-std/StdUtils.sol";

--- a/test/unit/concrete/Liquidation.t.sol
+++ b/test/unit/concrete/Liquidation.t.sol
@@ -7,8 +7,6 @@ import { LiquidationSharedSetup } from "../../helpers/LiquidationSharedSetup.sol
 import { Liquidation } from "../../../src/Liquidation.sol";
 import { WadRayMath } from "../../../src/libraries/math/WadRayMath.sol";
 
-import "forge-std/console.sol";
-
 contract MockstEthReserveOracle {
     uint256 public exchangeRate;
 

--- a/test/unit/concrete/SwEthHandler.t.sol
+++ b/test/unit/concrete/SwEthHandler.t.sol
@@ -7,7 +7,6 @@ import { Whitelist } from "../../../src/Whitelist.sol";
 import { IonPoolSharedSetup } from "../../helpers/IonPoolSharedSetup.sol";
 import { ERC20PresetMinterPauser } from "../../helpers/ERC20PresetMinterPauser.sol";
 
-import { IUniswapV3Factory } from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol";
 import { IUniswapV3Pool } from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 
 contract MockUniswapPool {

--- a/test/unit/concrete/WstEthHandler.t.sol
+++ b/test/unit/concrete/WstEthHandler.t.sol
@@ -7,7 +7,6 @@ import { Whitelist } from "../../../src/Whitelist.sol";
 import { IonPoolSharedSetup } from "../../helpers/IonPoolSharedSetup.sol";
 import { ERC20PresetMinterPauser } from "../../helpers/ERC20PresetMinterPauser.sol";
 
-import { IUniswapV3Factory } from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol";
 import { IUniswapV3Pool } from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 
 contract MockUniswapPool {

--- a/test/unit/fuzz/IonPool.t.sol
+++ b/test/unit/fuzz/IonPool.t.sol
@@ -819,8 +819,6 @@ abstract contract IonPool_BorrowerFuzzTestBase is IonPoolSharedSetup, IIonPoolEv
                     underlying.mint(borrower1, interestToPay);
                 }
 
-                console.log(ionPool.debt(), ionPool.debtUnaccrued(), totalDebtIncrease, totalChangeInDebt);
-
                 vm.expectEmit(true, true, true, true);
                 emit Repay(
                     i,


### PR DESCRIPTION
When adding a certain strategy to a collateral's handler, it can become quite a pain to copy and paste tests around. So we want to use inheritance in the tests as well to more easily reuse those. 

This add a bit of complexity in managing the tests however this will save more time in the long run allowing for faster appending of strategies to handlers.