### PR TITLE
M-01, N-01 WeEth Integration Audit

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -15,7 +15,13 @@ fs_permissions = [{ access = "read-write", path = "./"}]
 optimizer = true
 optimizer_runs = 400
 no_match_contract = "Echidna"
+<<<<<<< Updated upstream
 gas_reports = ["IonHandler", "IonRegistry", "TransparentUpgradeableProxy", "IonPool", "WstEthHandler", "EthXHandler", "SwEthHandler", "GemJoin", "InterestRate", "Whitelist"]
+=======
+no_match_path = "script/**/*.sol"
+gas_reports = ["IonHandler", "IonRegistry", "TransparentUpgradeableProxy", "IonPool", "WstEthHandler", "EthXHandler", "SwEthHandler", "GemJoin", "InterestRate", "Whitelist", "WeEthHandler"]
+evm_version = "paris"
+>>>>>>> Stashed changes
 
 [profile.default.fuzz]
 runs = 10000

--- a/src/flash/handlers/base/UniswapFlashswapDirectMintHandler.sol
+++ b/src/flash/handlers/base/UniswapFlashswapDirectMintHandler.sol
@@ -120,18 +120,18 @@ abstract contract UniswapFlashswapDirectMintHandler is IonHandlerBase, IUniswapV
             return;
         }
 
-        if (amountWethToFlashloan > maxResultingDebt) {
-            revert FlashloanRepaymentTooExpensive(amountWethToFlashloan, maxResultingDebt);
-        }
-
         // We want to swap for ETH here
         bool zeroForOne = MINT_IS_TOKEN0 ? false : true;
-        _initiateFlashSwap({
+        uint256 baseAssetSwappedIn = _initiateFlashSwap({
             zeroForOne: zeroForOne,
             amountOut: amountWethToFlashloan,
             recipient: address(this),
             data: abi.encode(msg.sender, resultingAdditionalCollateral, initialDeposit)
         });
+
+        if (baseAssetSwappedIn > maxResultingDebt) {
+            revert FlashloanRepaymentTooExpensive(amountWethToFlashloan, maxResultingDebt);
+        }
     }
 
     /**

--- a/src/oracles/reserve/ReserveOracle.sol
+++ b/src/oracles/reserve/ReserveOracle.sol
@@ -7,7 +7,7 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 // should equal to the number of feeds available in the contract
 uint8 constant FEED_COUNT = 3;
-uint256 constant UPDATE_COOLDOWN = 1 hours;
+uint256 constant UPDATE_COOLDOWN = 58 minutes;
 
 /**
  * @notice Reserve oracles are used to determine the LST provider exchange rate


### PR DESCRIPTION
- FIxes `maxResultingDebt` check to be against the right value.
- Also makes use of the return value from `initiateFlashswap()`