### PR TITLE
Reserve Factor Correct Input Validation

### DIFF
--- a/src/InterestRate.sol
+++ b/src/InterestRate.sol
@@ -156,7 +156,7 @@ contract InterestRate {
             if (ilkDataList[i].optimalUtilizationRate == 0) {
                 revert InvalidOptimalUtilizationRate(ilkDataList[i].optimalUtilizationRate);
             }
-            if (ilkDataList[i].reserveFactor > RAY) {
+            if (ilkDataList[i].reserveFactor > 1e4) {
                 revert InvalidReserveFactor(ilkDataList[i].reserveFactor);
             }
 


### PR DESCRIPTION
- The validation of the reserve factor was being done against `1e27` when it only has four decimals. It is now being compared against `1e4`.