### PR TITLE
OZ ezETH Audit Fixes

### DIFF
--- a/src/flash/UniswapFlashswapDirectMintHandlerWithDust.sol
+++ b/src/flash/UniswapFlashswapDirectMintHandlerWithDust.sol
@@ -10,7 +10,6 @@ import { IUniswapV3SwapCallback } from "@uniswap/v3-core/contracts/interfaces/ca
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { console2 } from "forge-std/console2.sol";
 
 /**
  * @notice This contract is forked off of the UniswapFlashswapDirectMintHandler,
@@ -28,7 +27,7 @@ import { console2 } from "forge-std/console2.sol";
  * of initial user deposit and additionally minted collateral to the caller's
  * requested resulting additional collateral amount.
  *
- * This contract allows for easy creation of leverge positions through a Uniswap
+ * This contract allows for easy creation of leverage positions through a Uniswap
  * flashswap and direct mint of the collateral from the provider. This will be
  * used when the collateral cannot be minted directly with the base asset but
  * can be directly minted by a token that the base asset has a UniswapV3 pool
@@ -94,6 +93,7 @@ abstract contract UniswapFlashswapDirectMintHandlerWithDust is IonHandlerBase, I
      * @param initialDeposit in collateral terms. [WAD]
      * @param resultingAdditionalCollateral in collateral terms. [WAD]
      * @param maxResultingDebt in base asset terms. [WAD]
+     * @param deadline The unix timestamp after which the uniswap transaction reverts.
      * @param proof used to validate the user is whitelisted.
      */
     function flashswapAndMint(

--- a/src/flash/lrt/EzEthHandler.sol
+++ b/src/flash/lrt/EzEthHandler.sol
@@ -7,7 +7,7 @@ import { Whitelist } from "../../Whitelist.sol";
 import { UniswapFlashswapDirectMintHandlerWithDust } from "./../UniswapFlashswapDirectMintHandlerWithDust.sol";
 import { IonHandlerBase } from "../IonHandlerBase.sol";
 import { RenzoLibrary } from "./../../libraries/lrt/RenzoLibrary.sol";
-import { EZETH, WETH_ADDRESS } from "../../Constants.sol";
+import { WETH_ADDRESS } from "../../Constants.sol";
 
 import { IUniswapV3Pool } from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 

--- a/src/libraries/lrt/RenzoLibrary.sol
+++ b/src/libraries/lrt/RenzoLibrary.sol
@@ -210,14 +210,15 @@ library RenzoLibrary {
         // _newValueAdded);
         //
         // Solve for _newValueAdded
-        uint256 ethAmountIn = inflationPercentage.mulDiv(_currentValueInProtocol, WAD - inflationPercentage);
-
-        if (inflationPercentage * _currentValueInProtocol % (WAD - inflationPercentage) != 0) {
-            // Unlikely to overflow
-            unchecked {
-                ethAmountIn++;
-            }
-        }
+        // NOTE This equation is intentionally rounded up. This is because if
+        // the division truncates and value is lost, the `ethAmountIn` in the
+        // forward compute will output less than the minimum `amountOut`. We
+        // round up to guarantee that the users will always only pay the minimum
+        // necessary amount for either the exact minimum amount out or the next
+        // closest possible mintable amount if the minimum amount out is not a
+        // mintable value.
+        uint256 ethAmountIn =
+            inflationPercentage.mulDiv(_currentValueInProtocol, WAD - inflationPercentage, Math.Rounding.Ceil);
 
         return ethAmountIn;
     }

--- a/src/libraries/lrt/RenzoLibrary.sol
+++ b/src/libraries/lrt/RenzoLibrary.sol
@@ -2,10 +2,9 @@
 pragma solidity 0.8.21;
 
 import { RENZO_RESTAKE_MANAGER, EZETH } from "../../Constants.sol";
-import { WadRayMath, WAD, RAY } from "../math/WadRayMath.sol";
+import { WadRayMath, WAD } from "../math/WadRayMath.sol";
 
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
-import { console2 } from "forge-std/console2.sol";
 
 using Math for uint256;
 using WadRayMath for uint256;
@@ -76,11 +75,12 @@ using WadRayMath for uint256;
  * We will call the range of values that produce the same amount of ezETH a
  * "mint range". The mint range for `0` ezETH is `0` to `227527` wei and the mint
  * range for `226219` ezETH is `227528` to `455054` wei.
+ *
+ * @custom:security-contact security@molecularlabs.io
  */
 
 library RenzoLibrary {
     error InvalidAmountOut(uint256 amountOut);
-    error InvalidAmountIn(uint256 amountIn);
 
     /**
      * @notice Returns the amount of ETH required to mint at least
@@ -212,7 +212,10 @@ library RenzoLibrary {
         // Solve for _newValueAdded
         uint256 ethAmountIn = inflationPercentage.mulDiv(_currentValueInProtocol, WAD - inflationPercentage);
 
-        ethAmountIn++;
+        // Unlikely to overflow
+        unchecked {
+            ethAmountIn++;
+        }
 
         return ethAmountIn;
     }

--- a/src/libraries/lrt/RenzoLibrary.sol
+++ b/src/libraries/lrt/RenzoLibrary.sol
@@ -212,9 +212,11 @@ library RenzoLibrary {
         // Solve for _newValueAdded
         uint256 ethAmountIn = inflationPercentage.mulDiv(_currentValueInProtocol, WAD - inflationPercentage);
 
-        // Unlikely to overflow
-        unchecked {
-            ethAmountIn++;
+        if (inflationPercentage * _currentValueInProtocol % (WAD - inflationPercentage) != 0) {
+            // Unlikely to overflow
+            unchecked {
+                ethAmountIn++;
+            }
         }
 
         return ethAmountIn;

--- a/src/libraries/uniswap/UniswapOracleLibrary.sol
+++ b/src/libraries/uniswap/UniswapOracleLibrary.sol
@@ -34,13 +34,15 @@ library UniswapOracleLibrary {
 
         // NOTE: Changed to match versions
         // arithmeticMeanTick = int24(tickCumulativesDelta / secondsAgo);
-        arithmeticMeanTick = int24(tickCumulativesDelta) / int24(int32(secondsAgo));
+        arithmeticMeanTick = int24(int256(tickCumulativesDelta) / int256(uint256(secondsAgo)));
 
         // Always round to negative infinity
 
         // NOTE: Changed to match versions
         // if (tickCumulativesDelta < 0 && (tickCumulativesDelta % secondsAgo != 0)) arithmeticMeanTick--;
-        if (tickCumulativesDelta < 0 && (tickCumulativesDelta % int56(int32(secondsAgo)) != 0)) arithmeticMeanTick--;
+        if (tickCumulativesDelta < 0 && (int256(tickCumulativesDelta) % int256(uint256(secondsAgo)) != 0)) {
+            arithmeticMeanTick--;
+        }
 
         // We are multiplying here instead of shifting to ensure that harmonicMeanLiquidity doesn't overflow uint128
         uint192 secondsAgoX160 = uint192(secondsAgo) * type(uint160).max;

--- a/src/oracles/spot/lrt/EzEthWstEthSpotOracle.sol
+++ b/src/oracles/spot/lrt/EzEthWstEthSpotOracle.sol
@@ -41,6 +41,9 @@ contract EzEthWstEthSpotOracle is SpotOracle {
     /**
      * @notice Gets the price of ezETH in wstETH
      * (ETH / ezETH) / (ETH / stETH) * (wstETH / stETH) = wstETH / ezETH
+     * @dev Redstone oracle returns ETH per ezETH with 8 decimals. This needs to
+     * be converted to wstETH per ezETH denomination.
+     * @return wstEthPerWeEth price of ezETH in wstETH. [WAD]
      */
     function getPrice() public view override returns (uint256) {
         // ETH / ezETH [8 decimals]

--- a/test/fork/fuzz/handlers-base/UniswapFlashswapDirectMintHandlerWithDust.t.sol
+++ b/test/fork/fuzz/handlers-base/UniswapFlashswapDirectMintHandlerWithDust.t.sol
@@ -10,8 +10,6 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 using WadRayMath for uint256;
 
-import { console2 } from "forge-std/console2.sol";
-
 struct Config {
     uint256 initialDepositLowerBound;
 }
@@ -48,8 +46,7 @@ abstract contract UniswapFlashswapDirectMintHandlerWithDust_FuzzTest is LrtHandl
         uint256 roundingError = currentRate / RAY;
         if (currentRate % RAY != 0) roundingError++;
 
-        // TODO: Can this dust amount be bounded at run-time?
-        uint256 maxDust = 400_000;
+        uint256 maxDust = 1e9;
 
         assertLt(
             ionPool.collateral(_getIlkIndex(), address(this)),

--- a/test/fork/fuzz/lrt/RenzoLibrary.t.sol
+++ b/test/fork/fuzz/lrt/RenzoLibrary.t.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.21;
 import { WAD, RAY, WadRayMath } from "./../../../../src/libraries/math/WadRayMath.sol";
 import { RenzoLibrary } from "../../../../src/libraries/lrt/RenzoLibrary.sol";
 import { EZETH, RENZO_RESTAKE_MANAGER } from "../../../../src/Constants.sol";
+import { EzEthHandler } from "./../../../../src/flash/lrt/EzEthHandler.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
-
 import { Test } from "forge-std/Test.sol";
 import { console2 } from "forge-std/console2.sol";
 
@@ -20,8 +20,8 @@ library MockRenzoLibrary {
 
     function mockCalculateMintAmount(
         uint256 _currentValueInProtocol,
-        uint256 _newValueAdded,
-        uint256 _existingEzETHSupply
+        uint256 _existingEzETHSupply,
+        uint256 _newValueAdded
     )
         public
         pure
@@ -47,8 +47,8 @@ library MockRenzoLibrary {
 
     function mockCalculateDepositAmount(
         uint256 totalTVL,
-        uint256 amountOut,
-        uint256 totalSupply
+        uint256 totalSupply,
+        uint256 amountOut
     )
         public
         pure
@@ -60,6 +60,7 @@ library MockRenzoLibrary {
         //
         // Solve for newEzETHSupply
         uint256 newEzEthSupply = (amountOut + totalSupply);
+        console2.log("newEzEthSupply: ", newEzEthSupply);
         uint256 newEzEthSupplyRay = newEzEthSupply.scaleUpToRay(18);
 
         //        uint256 newEzETHSupply = (_existingEzETHSupply * SCALE_FACTOR) / (SCALE_FACTOR -
@@ -85,8 +86,8 @@ library MockRenzoLibrary {
 
     // current math but with configurable totalTVL and totalSupply
     function mockGetEthAmountInForLstAmountOut(
-        uint256 totalSupply,
         uint256 totalTVL,
+        uint256 totalSupply,
         uint256 minAmountOut
     )
         public
@@ -99,8 +100,8 @@ library MockRenzoLibrary {
         // (,, uint256 totalTVL) = RENZO_RESTAKE_MANAGER.calculateTVLs();
         // uint256 totalSupply = EZETH.totalSupply();
 
-        uint256 ethAmount = mockCalculateDepositAmount(totalTVL, minAmountOut - 1, totalSupply);
-
+        uint256 ethAmount = mockCalculateDepositAmount(totalTVL, totalSupply, minAmountOut - 1);
+        console2.log("first calculated ethAmount: ", ethAmount);
         if (ethAmount == 0) return (0, 0);
         uint256 inflationPercentage = WAD * ethAmount / (totalTVL + ethAmount);
 
@@ -119,9 +120,9 @@ library MockRenzoLibrary {
         amountOut = newEzETHSupply - totalSupply;
 
         ethAmountIn = inflationPercentage.mulDiv(totalTVL, WAD - inflationPercentage, Math.Rounding.Ceil);
-
+        console2.log("second calculated ethAmountIn: ", ethAmountIn);
         // Very rarely, the `inflationPercentage` is less by one. So we try both.
-        if (mockCalculateMintAmount(totalTVL, ethAmountIn, totalSupply) >= minAmountOut) {
+        if (mockCalculateMintAmount(totalTVL, totalSupply, ethAmountIn) >= minAmountOut) {
             return (ethAmountIn, amountOut);
         }
 
@@ -131,7 +132,7 @@ library MockRenzoLibrary {
         newEzETHSupply = (totalSupply * WAD) / (WAD - inflationPercentage);
         amountOut = newEzETHSupply - totalSupply;
 
-        if (mockCalculateMintAmount(totalTVL, ethAmountIn, totalSupply) >= minAmountOut) {
+        if (mockCalculateMintAmount(totalTVL, totalSupply, ethAmountIn) >= minAmountOut) {
             return (ethAmountIn, amountOut);
         }
 
@@ -139,12 +140,10 @@ library MockRenzoLibrary {
     }
 }
 
-contract RenzoLibrary_FuzzTest is Test {
-    function setUp() public {
-        // vm.createSelectFork(vm.envString("MAINNET_RPC_URL"), 19387902);
-        vm.createSelectFork(vm.envString("MAINNET_RPC_URL"));
-    }
-
+contract RenzoLibraryHelper {
+    /**
+     * Copy of the private _calculateMintAmount function in RenzoLibrary.sol
+     */
     function forwardCompute(
         uint256 _existingEzETHSupply,
         uint256 _currentValueInProtocol,
@@ -159,7 +158,9 @@ contract RenzoLibrary_FuzzTest is Test {
         mintAmount = newEzETHSupply - _existingEzETHSupply;
     }
 
-    /// simpler back compute with default ethAmountIn++
+    /**
+     * Copy of the private _calculateDepositAmount function in RenzoLibrary.sol
+     */
     function backCompute(
         uint256 _existingEzETHSupply,
         uint256 _currentValueInProtocol,
@@ -181,72 +182,37 @@ contract RenzoLibrary_FuzzTest is Test {
 
         return ethAmountIn;
     }
+}
 
-    // --- Observations ---
-    // Max _existingEzETHSupply 10Me18 ($30B)
-    // _currentValueInProtocol = _existingEzETHSupply
-    // Max mintAmount _existingEzETHSupply / 2
-    // New Method: 1.75e7 fail, 1e8 pass
-    // Old Method: 1.75e7 fail, 1e8 pass
+contract RenzoLibrary_Comparison_FuzzTest is RenzoLibraryHelper, Test {
+    function setUp() public { }
 
-    // What happens when the Max _existingEzETHSupply increases?
-    // With all else equal, the dust increases.
-
-    // What happens when the minMintAmount relative to _existingEzETHSupply increases?
-    // With all else equal, if there is no bound, or if the bound is 100x the existing supply, dust increases
-
-    function testFuzz_NewMethodBackComputeDustBound(uint256 _existingEzETHSupply, uint128 minMintAmount) public {
+    /**
+     * Compare which method has a lower dust bound.
+     * Compare which method has a lower ethAmountIn.
+     * Old method dust is always greater than the new method dust.
+     * Out of 10000 runs,
+     * - 9576 runs have equal ethAmountIn.
+     * - 420 runs have old method ethAmountIn greater than new method ethAmountIn.
+     * - 2 runs have old method ethAmountIn less than new method ethAmountIn.
+     */
+    function testFuzz_BackComputeComparison(uint256 _existingEzETHSupply, uint128 minMintAmount) public {
         uint256 maxExistingEzETHSupply = 10_000_000e18;
-        _existingEzETHSupply = bound(_existingEzETHSupply, 1, maxExistingEzETHSupply);
+
+        _existingEzETHSupply = bound(_existingEzETHSupply, 1e18, maxExistingEzETHSupply);
 
         uint256 _currentValueInProtocol = _existingEzETHSupply * 1.1e18 / 1e18; // backed 1:1
 
-        minMintAmount = uint128(bound(uint256(minMintAmount), 0, _existingEzETHSupply / 2));
+        minMintAmount = uint128(bound(uint256(minMintAmount), 1e9, _existingEzETHSupply));
 
-        uint256 ethAmountIn = backCompute(_existingEzETHSupply, _currentValueInProtocol, minMintAmount);
-        uint256 actualMintAmountOut = forwardCompute(_existingEzETHSupply, _currentValueInProtocol, ethAmountIn);
-
-        vm.assume(actualMintAmountOut != 0);
-        assertGe(actualMintAmountOut, minMintAmount, "amount out comparison");
-
-        assertLe(actualMintAmountOut - minMintAmount, 1e9, "gwei bound");
-    }
-
-    function testFuzz_OldMethodBackComputeDustBound(uint256 _existingEzETHSupply, uint128 minMintAmount) public {
-        uint256 maxExistingEzETHSupply = 10_000_000e18;
-
-        _existingEzETHSupply = bound(_existingEzETHSupply, 1, maxExistingEzETHSupply);
-
-        uint256 _currentValueInProtocol = _existingEzETHSupply * 1.1e18 / 1e18; // backed 1:1
-
-        minMintAmount = uint128(bound(uint256(minMintAmount), 0, _existingEzETHSupply / 2));
-
-        (uint256 ethAmountIn, uint256 actualLrtAmount) = MockRenzoLibrary.mockGetEthAmountInForLstAmountOut(
-            _existingEzETHSupply, _currentValueInProtocol, minMintAmount
-        );
-        uint256 actualMintAmountOut = forwardCompute(_existingEzETHSupply, _currentValueInProtocol, ethAmountIn);
-
-        vm.assume(actualMintAmountOut != 0);
-        assertGe(actualMintAmountOut, minMintAmount, "amount out comparison");
-
-        assertLe(actualMintAmountOut - minMintAmount, 1e9, "gwei bound");
-    }
-
-    // --- Observations ---
-    // oldMethodDust is always greater than newMethodDust
-
-    function testFuzz_DustBoundComparison(uint256 _existingEzETHSupply, uint128 minMintAmount) public {
-        uint256 maxExistingEzETHSupply = 10_000_000e18;
-
-        _existingEzETHSupply = bound(_existingEzETHSupply, 1, maxExistingEzETHSupply);
-
-        uint256 _currentValueInProtocol = _existingEzETHSupply * 1.1e18 / 1e18; // backed 1:1
-
-        minMintAmount = uint128(bound(uint256(minMintAmount), 0, _existingEzETHSupply));
+        console2.log("_existingEzETHSupply: ", _existingEzETHSupply);
+        console2.log("_currentValueInProtocol: ", _currentValueInProtocol);
+        console2.log("minMintAmount: ", minMintAmount);
 
         (uint256 oldMethodEthAmountIn, uint256 actualLrtAmount) = MockRenzoLibrary.mockGetEthAmountInForLstAmountOut(
-            _existingEzETHSupply, _currentValueInProtocol, minMintAmount
+            _currentValueInProtocol, _existingEzETHSupply, minMintAmount
         );
+
         uint256 newMethodEthAmountIn = backCompute(_existingEzETHSupply, _currentValueInProtocol, minMintAmount);
 
         uint256 oldMethodActualMintAmountOut =
@@ -263,13 +229,17 @@ contract RenzoLibrary_FuzzTest is Test {
         console2.log("newMethodActualMintAmountOut: ", newMethodActualMintAmountOut);
 
         assertGe(
-            oldMethodEthAmountIn, newMethodEthAmountIn, "old method eth amount in is always greater than or equal to"
-        );
-        assertGe(
             oldMethodActualMintAmountOut,
             newMethodActualMintAmountOut,
-            "old method mint amount out is equal to new method mint amount out"
+            "old method mint amount out is greater than or equal to new method mint amount out"
         );
+        if (oldMethodEthAmountIn > newMethodEthAmountIn) {
+            vm.writeLine("fuzz_out.txt", "OLD METHOD ETH AMOUNT IN IS GREATER");
+        } else if (oldMethodEthAmountIn == newMethodEthAmountIn) {
+            vm.writeLine("fuzz_out.txt", "OLD METHOD ETH AMOUNT IN IS EQUAL");
+        } else {
+            vm.writeLine("fuzz_out.txt", "OLD METHOD ETH AMOUNT IN IS LESS");
+        }
         assertApproxEqAbs(oldMethodEthAmountIn, newMethodEthAmountIn, 1e9, "eth amount in approx eq");
 
         uint256 oldMethodDust = oldMethodActualMintAmountOut - minMintAmount;
@@ -280,31 +250,170 @@ contract RenzoLibrary_FuzzTest is Test {
 
         assertLe(newMethodDust, 1e9, "gwei bound"); // depends heavily on `maxExistingEzETHSupply`
     }
+}
 
-    function testForkFuzz_SimpleGetEthAmountInForLstAmountOutBounded(uint128 minMintAmount) public {
-        // back compute
-        (,, uint256 _currentValueInProtocol) = RENZO_RESTAKE_MANAGER.calculateTVLs();
-        uint256 _existingEzETHSupply = EZETH.totalSupply();
+contract RenzoLibrary_FuzzTest is RenzoLibraryHelper, Test {
+    /**
+     * -- Observations ---
+     * Max _existingEzETHSupply 10Me18 ($30B)
+     * _currentValueInProtocol = _existingEzETHSupply
+     * Max mintAmount _existingEzETHSupply / 2
+     * New Method: 1.75e7 fail, 1e8 pass
+     * Old Method: 1.75e7 fail, 1e8 pass
+     *
+     * Max _existingEzETHSupply 10Me19 (26 zeroes)
+     * 1e8 fails, 1e9 passes (9 zeroes)
+     *
+     * Max _existingEzETHSupply 10Me20 (27 zeroes)
+     * 1e9 fails, 1e10 passes (10 zeroes)
+     *
+     * Max _existingEzETHSupply 10Me21
+     * 1e10 fails, 1e11 passes
+     *
+     * Max _existingEzETHSuppply 10Me27
+     * 1e16 fails, 1e17 passes
+     *
+     * No proof, but max dust goes up 10x as the _existingEzETHSupply goes up 10x.
+     *
+     * Q: What happens when the Max _existingEzETHSupply increases?
+     * A: With all else equal, the dust increases.
+     *
+     * Q: What happens when the minMintAmount relative to _existingEzETHSupply increases?
+     * A: With all else equal, if there is no bound, or if the bound is 100x the existing supply, dust increases
+     *
+     * Q: What happens when the exchangeRate between ezETH and underlying increases?
+     * A: Even with very large exchange rates such as 10e18, the dust bound is not affected.
+     */
+    function testFuzz_BackComputeDustBound(uint256 _existingEzETHSupply, uint128 minMintAmount) public {
+        uint256 maxExistingEzETHSupply = 10_000_000e21;
+        _existingEzETHSupply = bound(_existingEzETHSupply, 1, maxExistingEzETHSupply);
 
-        // bound realistic mint amount with relation to existing ezETH supply
-        minMintAmount = uint128(bound(uint256(minMintAmount), 1, _existingEzETHSupply));
+        uint256 _currentValueInProtocol = _existingEzETHSupply * 1.2e18 / 1e18; // backed 1.2:1
 
-        uint256 ethAmountIn = backCompute(_existingEzETHSupply, _currentValueInProtocol, minMintAmount);
-        console2.log("back compute ethAmountIn: ", ethAmountIn);
+        minMintAmount = uint128(bound(uint256(minMintAmount), 0, _existingEzETHSupply / 2));
 
-        // forward compute simulation
-        // amount out must be greater than or equal to expected min amount out
-        uint256 actualMintAmountOut = _calculateMintAmount(ethAmountIn);
-        console2.log("actualMintAmountOut: ", actualMintAmountOut);
+        uint256 ethAmountIn = backCompute(_currentValueInProtocol, _existingEzETHSupply, minMintAmount);
+        uint256 actualMintAmountOut = forwardCompute(_currentValueInProtocol, _existingEzETHSupply, ethAmountIn);
+
+        vm.assume(actualMintAmountOut != 0);
+        assertGe(actualMintAmountOut, minMintAmount, "amount out comparison");
+
+        assertLe(actualMintAmountOut - minMintAmount, 1e11, "gwei bound");
+    }
+
+    /**
+     * _existingEzETHSupply / 10**17 bound passes with:
+     * - _existingEzETHSupply [1e18, type(uint128).max]
+     * - exchangeRate [1e18, 8e18]
+     * - minMintAmount [0, _existingEzETHSupply]
+     */
+    function testFuzz_BackComputeFormulaicDustBound(
+        uint256 _existingEzETHSupply,
+        uint128 minMintAmount,
+        uint128 exchangeRate
+    )
+        public
+    {
+        _existingEzETHSupply = bound(_existingEzETHSupply, WAD, type(uint128).max);
+
+        exchangeRate = uint128(bound(exchangeRate, 1e18, 8e18)); // 9e18 fails
+
+        uint256 _currentValueInProtocol = _existingEzETHSupply * exchangeRate / 1e18;
+
+        minMintAmount = uint128(bound(uint256(minMintAmount), 0, _existingEzETHSupply));
+
+        uint256 ethAmountIn = backCompute(_currentValueInProtocol, _existingEzETHSupply, minMintAmount);
+        uint256 actualMintAmountOut = forwardCompute(_currentValueInProtocol, _existingEzETHSupply, ethAmountIn);
+
+        uint256 dustBound = _existingEzETHSupply / 10 ** 17;
+
         vm.assume(actualMintAmountOut != 0);
 
         assertGe(actualMintAmountOut, minMintAmount, "amount out comparison");
 
-        assertLe(actualMintAmountOut - minMintAmount, 1e7, "bound");
+        assertLe(actualMintAmountOut - minMintAmount, dustBound, "exact dust bound");
+    }
 
-        vm.deal(address(this), ethAmountIn);
-        RenzoLibrary.depositForLrt(ethAmountIn);
-        assertEq(EZETH.balanceOf(address(this)), actualMintAmountOut, "ezETH balance check");
+    function testFuzz_BackComputeRealisticDustBound(
+        uint256 _existingEzETHSupply,
+        uint128 minMintAmount,
+        uint128 exchangeRate
+    )
+        public
+    {
+        // There are 120M circulating ETH as of 4/9/2024.
+        _existingEzETHSupply = bound(_existingEzETHSupply, WAD, 120_000_000e18);
+        // realistically, the exchangeRate will not more than double
+        exchangeRate = uint128(bound(exchangeRate, 1e18, 2e18));
+        // realistically, a single mint would not be double the entire supply
+        minMintAmount = uint128(bound(uint256(minMintAmount), 0, _existingEzETHSupply * 2));
+
+        uint256 _currentValueInProtocol = _existingEzETHSupply * exchangeRate / 1e18;
+
+        uint256 ethAmountIn = backCompute(_currentValueInProtocol, _existingEzETHSupply, minMintAmount);
+        uint256 actualMintAmountOut = forwardCompute(_currentValueInProtocol, _existingEzETHSupply, ethAmountIn);
+
+        uint256 dustBound = 1e10;
+
+        vm.assume(actualMintAmountOut != 0);
+
+        assertGe(actualMintAmountOut, minMintAmount, "amount out comparison");
+        assertLe(actualMintAmountOut - minMintAmount, dustBound, "exact dust bound");
+    }
+
+    function testFuzz_BackComputeResultIsOptimal(
+        uint256 _existingEzETHSupply,
+        uint128 minMintAmount,
+        uint128 exchangeRate
+    )
+        public
+    {
+        uint256 maxExistingEzETHSupply = 10_000_000e18;
+
+        _existingEzETHSupply = bound(_existingEzETHSupply, 1, maxExistingEzETHSupply);
+        exchangeRate = uint128(bound(exchangeRate, 1e18, 2e18));
+        minMintAmount = uint128(bound(uint256(minMintAmount), 0, _existingEzETHSupply));
+
+        uint256 _currentValueInProtocol = _existingEzETHSupply * exchangeRate / 1e18;
+
+        uint256 ethAmountIn = backCompute(_currentValueInProtocol, _existingEzETHSupply, minMintAmount);
+        uint256 actualMintAmountOut = forwardCompute(_currentValueInProtocol, _existingEzETHSupply, ethAmountIn);
+
+        vm.assume(ethAmountIn != 0);
+
+        // try minting with one less
+        uint256 mintAmountOutWithOneLess =
+            forwardCompute(_currentValueInProtocol, _existingEzETHSupply, ethAmountIn - 1);
+
+        if (mintAmountOutWithOneLess < minMintAmount) {
+            vm.writeLine("fuzz_out.txt", "REDUCED MINT AMOUNT IS LESS");
+        } else if (mintAmountOutWithOneLess == minMintAmount) {
+            vm.writeLine("fuzz_out.txt", "REDUCED MINT AMOUNT IS EQUAL");
+        } else {
+            vm.writeLine("fuzz_out.txt", "REDUCED MINT AMOUNT IS GREATER");
+        }
+        // if (mintAmountOutWithOneLess < actualMintAmountOut) {
+        //     vm.writeLine("fuzz_out.txt", "REDUCED MINT AMOUNT IS LESS");
+        // } else if (mintAmountOutWithOneLess == actualMintAmountOut) {
+        //     vm.writeLine("fuzz_out.txt", "REDUCED MINT AMOUNT IS EQUAL");
+        // } else {
+        //     vm.writeLine("fuzz_out.txt", "REDUCED MINT AMOUNT IS GREATER");
+        // }
+
+        assertLe(mintAmountOutWithOneLess, minMintAmount, "one less eth amount comopared to min mint amount");
+        assertLe(mintAmountOutWithOneLess, actualMintAmountOut, "one less eth amount compared to actual mint amount");
+
+        vm.assume(actualMintAmountOut != 0);
+        assertGe(actualMintAmountOut, minMintAmount, "amount out comparison");
+
+        assertLe(actualMintAmountOut - minMintAmount, 1e11, "gwei bound");
+    }
+}
+
+contract RenzoLibrary_ForkFuzzTest is RenzoLibraryHelper, Test {
+    function setUp() public {
+        // vm.createSelectFork(vm.envString("MAINNET_RPC_URL"), 19387902);
+        vm.createSelectFork(vm.envString("MAINNET_RPC_URL"));
     }
 
     function test_GetEthAmountInForLstAmountOut() public {
@@ -332,6 +441,19 @@ contract RenzoLibrary_FuzzTest is Test {
         assertEq(EZETH.balanceOf(address(this)), actualLrtAmount, "ezETH balance");
     }
 
+    function testForkFuzz_GetEthAmountInForLstAmountOutWithDustBound(uint128 minLrtAmount) public {
+        uint256 _existingEzETHSupply = EZETH.totalSupply();
+        minLrtAmount = uint128(bound(uint256(minLrtAmount), 1, _existingEzETHSupply));
+
+        (uint256 ethAmount, uint256 actualLrtAmount) = RenzoLibrary.getEthAmountInForLstAmountOut(minLrtAmount);
+        assertGe(actualLrtAmount, minLrtAmount, "actualLrtAmount");
+
+        uint256 mintAmount = _calculateMintAmount(ethAmount);
+        vm.assume(mintAmount != 0);
+
+        assertLe(mintAmount - minLrtAmount, 1e8, "hard coded dust bound");
+    }
+
     function testForkFuzz_GetLstAmountOutForEthAmountIn(uint128 ethAmount) public {
         uint256 mintAmount = _calculateMintAmount(ethAmount);
 
@@ -349,6 +471,15 @@ contract RenzoLibrary_FuzzTest is Test {
         vm.deal(address(this), ethAmount);
         RenzoLibrary.depositForLrt(ethAmount);
         assertEq(EZETH.balanceOf(address(this)), lrtAmountOut);
+    }
+
+    /**
+     * The optimal amount should always be less than the original input amount.
+     * Depositing one less than the optimal amount should be below the necessary mint amount.
+     */
+    function testForkFuzz_GetLstAmountOutForEthAmountInOptimalAmount(uint128 ethAmount) public {
+        (uint256 amount, uint256 optimalAmount) = RenzoLibrary.getLstAmountOutForEthAmountIn(ethAmount);
+        assertLe(optimalAmount, ethAmount, "optimalAmount");
     }
 
     function _calculateMintAmount(uint256 ethAmount) internal view returns (uint256 mintAmount) {

--- a/test/fork/fuzz/lrt/RenzoLibrary.t.sol
+++ b/test/fork/fuzz/lrt/RenzoLibrary.t.sol
@@ -1,19 +1,310 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.21;
 
+import { WAD, RAY, WadRayMath } from "./../../../../src/libraries/math/WadRayMath.sol";
 import { RenzoLibrary } from "../../../../src/libraries/lrt/RenzoLibrary.sol";
 import { EZETH, RENZO_RESTAKE_MANAGER } from "../../../../src/Constants.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import { Test } from "forge-std/Test.sol";
+import { console2 } from "forge-std/console2.sol";
 
-import { safeconsole as console } from "forge-std/safeconsole.sol";
+using Math for uint256;
+using WadRayMath for uint256;
 
 uint256 constant SCALE_FACTOR = 1e18;
+
+library MockRenzoLibrary {
+    error InvalidAmountOut(uint256 amountOut);
+    error InvalidAmountIn(uint256 amountIn);
+
+    function mockCalculateMintAmount(
+        uint256 _currentValueInProtocol,
+        uint256 _newValueAdded,
+        uint256 _existingEzETHSupply
+    )
+        public
+        pure
+        returns (uint256)
+    {
+        // For first mint, just return the new value added.
+        // Checking both current value and existing supply to guard against gaming the initial mint
+        if (_currentValueInProtocol == 0 || _existingEzETHSupply == 0) {
+            return _newValueAdded; // value is priced in base units, so divide by scale factor
+        }
+
+        // Calculate the percentage of value after the deposit
+        uint256 inflationPercentage = WAD * _newValueAdded / (_currentValueInProtocol + _newValueAdded);
+
+        // Calculate the new supply
+        uint256 newEzETHSupply = (_existingEzETHSupply * WAD) / (WAD - inflationPercentage);
+
+        // Subtract the old supply from the new supply to get the amount to mint
+        uint256 mintAmount = newEzETHSupply - _existingEzETHSupply;
+
+        return mintAmount;
+    }
+
+    function mockCalculateDepositAmount(
+        uint256 totalTVL,
+        uint256 amountOut,
+        uint256 totalSupply
+    )
+        public
+        pure
+        returns (uint256)
+    {
+        if (amountOut == 0) return 0;
+
+        //        uint256 mintAmount = newEzETHSupply - _existingEzETHSupply;
+        //
+        // Solve for newEzETHSupply
+        uint256 newEzEthSupply = (amountOut + totalSupply);
+        uint256 newEzEthSupplyRay = newEzEthSupply.scaleUpToRay(18);
+
+        //        uint256 newEzETHSupply = (_existingEzETHSupply * SCALE_FACTOR) / (SCALE_FACTOR -
+        // inflationPercentage);
+        //
+        // Solve for inflationPercentage
+        uint256 intem = totalSupply.scaleUpToRay(18).mulDiv(RAY, newEzEthSupplyRay);
+        uint256 inflationPercentage = RAY - intem;
+
+        //         uint256 inflationPercentage = SCALE_FACTOR * _newValueAdded / (_currentValueInProtocol +
+        // _newValueAdded);
+        //
+        // Solve for _newValueAdded
+        uint256 ethAmountRay = inflationPercentage.mulDiv(totalTVL.scaleUpToRay(18), RAY - inflationPercentage);
+
+        // Truncate from RAY to WAD with roundingUp plus one extra
+        // The one extra to get into the next mint range
+        uint256 ethAmount = ethAmountRay / 1e9 + 1;
+        if (ethAmountRay % 1e9 != 0) ++ethAmount;
+
+        return ethAmount;
+    }
+
+    // current math but with configurable totalTVL and totalSupply
+    function mockGetEthAmountInForLstAmountOut(
+        uint256 totalSupply,
+        uint256 totalTVL,
+        uint256 minAmountOut
+    )
+        public
+        view
+        returns (uint256 ethAmountIn, uint256 amountOut)
+    {
+        if (minAmountOut == 0) return (0, 0);
+
+        // passed in as params
+        // (,, uint256 totalTVL) = RENZO_RESTAKE_MANAGER.calculateTVLs();
+        // uint256 totalSupply = EZETH.totalSupply();
+
+        uint256 ethAmount = mockCalculateDepositAmount(totalTVL, minAmountOut - 1, totalSupply);
+
+        if (ethAmount == 0) return (0, 0);
+        uint256 inflationPercentage = WAD * ethAmount / (totalTVL + ethAmount);
+
+        // Once we have the `inflationPercentage` mapping to the "mintable amount"
+        // below `minAmountOut`, we increment it to find the
+        // `inflationPercentage` mapping to the "mintable amount" above
+        // `minAmountOut".
+        ++inflationPercentage;
+
+        // Then we go on to calculate the ezETH amount and optimal eth deposit
+        // mapping to that `inflationPercentage`.
+
+        // Calculate the new supply
+        uint256 newEzETHSupply = (totalSupply * WAD) / (WAD - inflationPercentage);
+
+        amountOut = newEzETHSupply - totalSupply;
+
+        ethAmountIn = inflationPercentage.mulDiv(totalTVL, WAD - inflationPercentage, Math.Rounding.Ceil);
+
+        // Very rarely, the `inflationPercentage` is less by one. So we try both.
+        if (mockCalculateMintAmount(totalTVL, ethAmountIn, totalSupply) >= minAmountOut) {
+            return (ethAmountIn, amountOut);
+        }
+
+        ++inflationPercentage;
+        ethAmountIn = inflationPercentage.mulDiv(totalTVL, WAD - inflationPercentage, Math.Rounding.Ceil);
+
+        newEzETHSupply = (totalSupply * WAD) / (WAD - inflationPercentage);
+        amountOut = newEzETHSupply - totalSupply;
+
+        if (mockCalculateMintAmount(totalTVL, ethAmountIn, totalSupply) >= minAmountOut) {
+            return (ethAmountIn, amountOut);
+        }
+
+        revert InvalidAmountOut(ethAmountIn);
+    }
+}
 
 contract RenzoLibrary_FuzzTest is Test {
     function setUp() public {
         // vm.createSelectFork(vm.envString("MAINNET_RPC_URL"), 19387902);
         vm.createSelectFork(vm.envString("MAINNET_RPC_URL"));
+    }
+
+    function forwardCompute(
+        uint256 _existingEzETHSupply,
+        uint256 _currentValueInProtocol,
+        uint256 ethAmountIn
+    )
+        public
+        pure
+        returns (uint256 mintAmount)
+    {
+        uint256 inflationPercentage = SCALE_FACTOR * ethAmountIn / (_currentValueInProtocol + ethAmountIn);
+        uint256 newEzETHSupply = (_existingEzETHSupply * SCALE_FACTOR) / (SCALE_FACTOR - inflationPercentage);
+        mintAmount = newEzETHSupply - _existingEzETHSupply;
+    }
+
+    /// simpler back compute with default ethAmountIn++
+    function backCompute(
+        uint256 _existingEzETHSupply,
+        uint256 _currentValueInProtocol,
+        uint256 mintAmount
+    )
+        public
+        pure
+        returns (uint256)
+    {
+        if (mintAmount == 0) return 0;
+
+        uint256 newEzETHSupply = mintAmount + _existingEzETHSupply;
+
+        uint256 inflationPercentage = SCALE_FACTOR - ((SCALE_FACTOR * _existingEzETHSupply) / newEzETHSupply);
+
+        uint256 ethAmountIn = inflationPercentage * _currentValueInProtocol / (SCALE_FACTOR - inflationPercentage);
+
+        ethAmountIn++; // always increment by default
+
+        return ethAmountIn;
+    }
+
+    // --- Observations ---
+    // Max _existingEzETHSupply 10Me18 ($30B)
+    // _currentValueInProtocol = _existingEzETHSupply
+    // Max mintAmount _existingEzETHSupply / 2
+    // New Method: 1.75e7 fail, 1e8 pass
+    // Old Method: 1.75e7 fail, 1e8 pass
+
+    // What happens when the Max _existingEzETHSupply increases?
+    // With all else equal, the dust increases.
+
+    // What happens when the minMintAmount relative to _existingEzETHSupply increases?
+    // With all else equal, if there is no bound, or if the bound is 100x the existing supply, dust increases
+
+    function testFuzz_NewMethodBackComputeDustBound(uint256 _existingEzETHSupply, uint128 minMintAmount) public {
+        uint256 maxExistingEzETHSupply = 10_000_000e18;
+        _existingEzETHSupply = bound(_existingEzETHSupply, 1, maxExistingEzETHSupply);
+
+        uint256 _currentValueInProtocol = _existingEzETHSupply * 1.1e18 / 1e18; // backed 1:1
+
+        minMintAmount = uint128(bound(uint256(minMintAmount), 0, _existingEzETHSupply / 2));
+
+        uint256 ethAmountIn = backCompute(_existingEzETHSupply, _currentValueInProtocol, minMintAmount);
+        uint256 actualMintAmountOut = forwardCompute(_existingEzETHSupply, _currentValueInProtocol, ethAmountIn);
+
+        vm.assume(actualMintAmountOut != 0);
+        assertGe(actualMintAmountOut, minMintAmount, "amount out comparison");
+
+        assertLe(actualMintAmountOut - minMintAmount, 1e9, "gwei bound");
+    }
+
+    function testFuzz_OldMethodBackComputeDustBound(uint256 _existingEzETHSupply, uint128 minMintAmount) public {
+        uint256 maxExistingEzETHSupply = 10_000_000e18;
+
+        _existingEzETHSupply = bound(_existingEzETHSupply, 1, maxExistingEzETHSupply);
+
+        uint256 _currentValueInProtocol = _existingEzETHSupply * 1.1e18 / 1e18; // backed 1:1
+
+        minMintAmount = uint128(bound(uint256(minMintAmount), 0, _existingEzETHSupply / 2));
+
+        (uint256 ethAmountIn, uint256 actualLrtAmount) = MockRenzoLibrary.mockGetEthAmountInForLstAmountOut(
+            _existingEzETHSupply, _currentValueInProtocol, minMintAmount
+        );
+        uint256 actualMintAmountOut = forwardCompute(_existingEzETHSupply, _currentValueInProtocol, ethAmountIn);
+
+        vm.assume(actualMintAmountOut != 0);
+        assertGe(actualMintAmountOut, minMintAmount, "amount out comparison");
+
+        assertLe(actualMintAmountOut - minMintAmount, 1e9, "gwei bound");
+    }
+
+    // --- Observations ---
+    // oldMethodDust is always greater than newMethodDust
+
+    function testFuzz_DustBoundComparison(uint256 _existingEzETHSupply, uint128 minMintAmount) public {
+        uint256 maxExistingEzETHSupply = 10_000_000e18;
+
+        _existingEzETHSupply = bound(_existingEzETHSupply, 1, maxExistingEzETHSupply);
+
+        uint256 _currentValueInProtocol = _existingEzETHSupply * 1.1e18 / 1e18; // backed 1:1
+
+        minMintAmount = uint128(bound(uint256(minMintAmount), 0, _existingEzETHSupply));
+
+        (uint256 oldMethodEthAmountIn, uint256 actualLrtAmount) = MockRenzoLibrary.mockGetEthAmountInForLstAmountOut(
+            _existingEzETHSupply, _currentValueInProtocol, minMintAmount
+        );
+        uint256 newMethodEthAmountIn = backCompute(_existingEzETHSupply, _currentValueInProtocol, minMintAmount);
+
+        uint256 oldMethodActualMintAmountOut =
+            forwardCompute(_existingEzETHSupply, _currentValueInProtocol, oldMethodEthAmountIn);
+        uint256 newMethodActualMintAmountOut =
+            forwardCompute(_existingEzETHSupply, _currentValueInProtocol, newMethodEthAmountIn);
+
+        vm.assume(oldMethodActualMintAmountOut != 0);
+        vm.assume(newMethodActualMintAmountOut != 0);
+
+        console2.log("oldMethodEthAmountIn: ", oldMethodEthAmountIn);
+        console2.log("newMethodEthAmountIn: ", newMethodEthAmountIn);
+        console2.log("oldMethodActualMintAmountOut: ", oldMethodActualMintAmountOut);
+        console2.log("newMethodActualMintAmountOut: ", newMethodActualMintAmountOut);
+
+        assertGe(
+            oldMethodEthAmountIn, newMethodEthAmountIn, "old method eth amount in is always greater than or equal to"
+        );
+        assertGe(
+            oldMethodActualMintAmountOut,
+            newMethodActualMintAmountOut,
+            "old method mint amount out is equal to new method mint amount out"
+        );
+        assertApproxEqAbs(oldMethodEthAmountIn, newMethodEthAmountIn, 1e9, "eth amount in approx eq");
+
+        uint256 oldMethodDust = oldMethodActualMintAmountOut - minMintAmount;
+        uint256 newMethodDust = newMethodActualMintAmountOut - minMintAmount;
+
+        assertGe(oldMethodDust, newMethodDust, "old method dust is greater than or equal to new method dust");
+        assertLe(oldMethodDust - newMethodDust, 1e9, "dust differential bound");
+
+        assertLe(newMethodDust, 1e9, "gwei bound"); // depends heavily on `maxExistingEzETHSupply`
+    }
+
+    function testForkFuzz_SimpleGetEthAmountInForLstAmountOutBounded(uint128 minMintAmount) public {
+        // back compute
+        (,, uint256 _currentValueInProtocol) = RENZO_RESTAKE_MANAGER.calculateTVLs();
+        uint256 _existingEzETHSupply = EZETH.totalSupply();
+
+        // bound realistic mint amount with relation to existing ezETH supply
+        minMintAmount = uint128(bound(uint256(minMintAmount), 1, _existingEzETHSupply));
+
+        uint256 ethAmountIn = backCompute(_existingEzETHSupply, _currentValueInProtocol, minMintAmount);
+        console2.log("back compute ethAmountIn: ", ethAmountIn);
+
+        // forward compute simulation
+        // amount out must be greater than or equal to expected min amount out
+        uint256 actualMintAmountOut = _calculateMintAmount(ethAmountIn);
+        console2.log("actualMintAmountOut: ", actualMintAmountOut);
+        vm.assume(actualMintAmountOut != 0);
+
+        assertGe(actualMintAmountOut, minMintAmount, "amount out comparison");
+
+        assertLe(actualMintAmountOut - minMintAmount, 1e7, "bound");
+
+        vm.deal(address(this), ethAmountIn);
+        RenzoLibrary.depositForLrt(ethAmountIn);
+        assertEq(EZETH.balanceOf(address(this)), actualMintAmountOut, "ezETH balance check");
     }
 
     function test_GetEthAmountInForLstAmountOut() public {

--- a/test/fork/fuzz/lrt/RenzoLibrary.t.sol
+++ b/test/fork/fuzz/lrt/RenzoLibrary.t.sol
@@ -181,7 +181,9 @@ contract RenzoLibraryHelper {
 
         uint256 ethAmountIn = inflationPercentage * _currentValueInProtocol / (SCALE_FACTOR - inflationPercentage);
 
-        ethAmountIn++; // always increment by default
+        if (inflationPercentage * _currentValueInProtocol % (SCALE_FACTOR - inflationPercentage) != 0) {
+            ethAmountIn++;
+        }
 
         return ethAmountIn;
     }


### PR DESCRIPTION
## TODOs
### OZ
- [x] ezETH Library Changes
- [x] `L-01` Incomplete Docstrings
    - Changes in `EzEthWstEthSpotOracle.sol` and `UniswapFlashswapDirectMintHandlerWithDust.sol`
- [x] `N-01` Incremental update in an unchecked block
- [x] `N-02` Unused error `InvalidAmountIn` removed 
- [x] `N-04` Security contract to `RenzoLibrary.sol`
- [x] `N-06` Typo 
### Shieldify 
- [x] `UniswapOracleLibrary` potential truncation when casting


## ezETH Library Changes
The main problem is that due to multiple truncating divisions, there may be a broad range of `ethAmountIn` that leads to the same`mintAmountOut`. There are two goals to the ezETH library with regards to handling this rounding error induced by the Renzo math.
1. Minimize cost for users by allowing them to reach the desired `mintAmountOut` at the lowest possible `ethAmountIn`. 
2. Minimize the difference between the desired mint amount and the actual mint amount, minimizing the difference in expected and actual deposit amount. 

### Old Method vs. New Method Comparison 
- The old method refers to the `getEthAmountInForLstAmountOut` function that this PR modifies, which began by calculating the `ethAmountIn` with `mintAmountOut - 1`, and subsequently incrementing the `inflationPercentage`. 
- The new method refers to the `getEthAmountInForLstAmountOut` function in this PR, which does a simple backcompute, and rounds up the final `ethAmountIn`. 
- Although we show things empirically via fuzz, we do not yet have a formal theoretical understanding of the rounding behavior, so we resort to observations to make this decision. 

#### 1. Changes in the dust bound [Old vs. New] 
- Fuzz Setup
    - `_existingEzETHSupply` bounded between `[1e18, 120Me18]` (120Me18 being an absurdly high existing ezETH supply). 
    - `exchangeRate` bounded between `[1e18, 3e18]`. 
    - `minMintAmount` bounded between `[1e9, _existingEzETHSupply]` (Assumes that no one mint amount is greater than the entire supply). 
- Observations
    - The old method dust is always greater than new method dust 
    - The difference between the old method dust and the new method dust bound is approximately 1e9. 
    - Out of 100K runs, 
        - 148 runs had `old method dust < new method dust`. 
        - 2329 runs had `old method dust > new method dust`
        - 97523 runs had `old method dust == new method dust`
- Summary
    - Most of the times, the two methods were equal, but the new method reduced the dust amount in ~2% of the overall runs. 
        
#### 2. Changes in the `ethAmountIn` [Old vs. New] 
- The goal is to minimize the `ethAmountIn` while minting at least the minimum amount out. 
- Observations
  - Out of 10K fuzz results, 
      - 9576 runs resulted in equal ethAmountIn’s 
      - 420 runs resulted in old method ethAmountIn greater than new method ethAmountIn
      - 2 runs resulted in old method ethAountIn less than new method ethAmountIn 
  - Out of 100K fuzz 
      - 156 runs had `old method ethAmountIn < new method ethAmountIn`
      - 2400 runs had `old method ethAmountIn > new method ethAmountIn`
      - 97444 runs had `old method ethAmountIn == new method ethAmountIn`
- Summary 
    - Again, most of the times, the two methods were equal, but the new method more frequently minimized the `ethAmountIn`. 
      
### New Method Fuzz
      
#### 1. Is the new backcompute always optimal for users? 
- We consider the ethAmountIn to be optimal "if one less than the ethAmountIn would have resulted in a mintAmount less than the minimum amount out."
- Out of 100K fuzz results
    - The output of `ethAmountIn - 1` was always strictly less than the output of `ethAmountIn`, showing that this `ethAmountIn` was optimal. 
      
#### 2. Is there an exact maximum dust bound? 
- We still don’t have a theoretical bound to the maximum amount of dust that can be greated given the user input and known variables. This fuzz sets out some guarantees at ‘realistic’ worst-case values. 
- Fuzz Setup 
    - Max bound for existingEzETH fuzzed assuming all circulating ETH turns to ezETH. ~120Me18 tokens. 
    - The exchangeRate will most likely not exceed 2e18 (doubling value through staking yield). 
    - The incoming mint amount being less than double the entire supply of ezETH (impossible since we are also assuming that ). 
- Observations 
    - Even fuzzed with these extreme max bounds, the max dust does not exceed 1e9. 

### Conclusion
1. With the fuzz, we can see that the `ethAmountIn` is optimal. 
2. There is no formulaic bound on max dust, but there is a realistic-worst-case bound. 
The new method simplifies logic and is shown to lower cost for users (with smaller ethAmountIn) and with lower dust (which doesn’t affect ‘cost’ as the dust gets deposited into user vaults, but reduces the non-exact behavior of the contract). 

      
    
    
