### PR TITLE
OZ Fix: ezETH Renzo Library Rounding

### DIFF
--- a/src/libraries/lrt/RenzoLibrary.sol
+++ b/src/libraries/lrt/RenzoLibrary.sol
@@ -2,13 +2,12 @@
 pragma solidity 0.8.21;
 
 import { RENZO_RESTAKE_MANAGER, EZETH } from "../../Constants.sol";
-import { WadRayMath, WAD, RAY } from "../math/WadRayMath.sol";
+import { WadRayMath, WAD } from "../math/WadRayMath.sol";
 
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 using Math for uint256;
 using WadRayMath for uint256;
-
 /**
  * @title RenzoLibrary
  *
@@ -76,10 +75,12 @@ using WadRayMath for uint256;
  * We will call the range of values that produce the same amount of ezETH a
  * "mint range". The mint range for `0` ezETH is `0` to `227527` wei and the mint
  * range for `226219` ezETH is `227528` to `455054` wei.
+ *
+ * @custom:security-contact security@molecularlabs.io
  */
+
 library RenzoLibrary {
     error InvalidAmountOut(uint256 amountOut);
-    error InvalidAmountIn(uint256 amountIn);
 
     /**
      * @notice Returns the amount of ETH required to mint at least
@@ -93,6 +94,24 @@ library RenzoLibrary {
      * lower bound of the "mint range" of the "mintable amount" right above
      * `minAmountOut`.
      *
+     * There exists an edge case where `minAmountOut` is an exact "mintable amount". Continuing with the
+     * example from block 19387902, if `minAmountOut` is `226218`, the
+     * `inflationPercentage` below would be 0. It would then be incremented
+     * to 1 and then when deriving the true `amountOut` from the incremented
+     * `inflationPercentage`, it would get `amountOut = 226219`. However, if
+     * `minAmountOut` is `226219`, the `inflationPercentage` below would be
+     * 1 and it would be incremented to 2. Then, true `amountOut` would then
+     * be `452438` which is unnecessarily minting more when the initial
+     * "mintable amount" was perfect.
+     *
+     * In this case, the inflationPercentage that the
+     * `_calculateDepositAmount`'s `ethAmountIn` maps to may not be the most
+     * optimal and users may incur the cost of paying extra dust for the same
+     * mint amount. However, we have empirically observed via fuzzing that 90%
+     * of the time, the ethAmountIn calculated through this function will be the
+     * most optimal eth amount in, and one less the `ethAmountIn` will result in
+     * a mint amount out lower than the minimum.
+     *
      * @param minAmountOut Minimum amount of ezETH to mint
      * @return ethAmountIn Amount of ETH required to mint the desired amount of
      * ezETH
@@ -105,63 +124,14 @@ library RenzoLibrary {
     {
         if (minAmountOut == 0) return (0, 0);
 
-        (,, uint256 totalTVL) = RENZO_RESTAKE_MANAGER.calculateTVLs();
-        uint256 totalSupply = EZETH.totalSupply();
+        (,, uint256 _currentValueInProtocol) = RENZO_RESTAKE_MANAGER.calculateTVLs();
+        uint256 _existingEzETHSupply = EZETH.totalSupply();
 
-        // Each `inflationPercentage` maps to a "mintable amount" and, therefore,
-        // there exists a "mint range" that maps to a single
-        // `inflationPercentage` and a single "mint amount".
+        ethAmountIn = _calculateDepositAmount(_currentValueInProtocol, _existingEzETHSupply, minAmountOut);
+        if (ethAmountIn == 0) return (0, 0);
 
-        // We need to first calculate the `inflationPercentage` that maps to the
-        // "mint range" of the `minAmountOut`.
-
-        // Technically, the specified `minAmountOut` is unlikely to be mintable
-        // given the rounding errors. But we can find the mint range of the
-        // "mint amount" below `minAmountOut
-        //
-        // To understand the reason for using `minAmountOut - 1`, consider the
-        // case where `minAmountOut` is a "mint amount". Continuing with the
-        // example from block 19387902, if `minAmountOut` is `226218`, the
-        // `inflationPercentage` below would be 0. It would then be incremented
-        // to 1 and then when deriving the true `amountOut` from the incremented
-        // `inflationPercentage`, it would get `amountOut = 226219`. However, if
-        // `minAmountOut` is `226219`, the `inflationPercentage` below would be
-        // 1 and it would be incremented to 2. Then, true `amountOut` would then
-        // be `452438` which is unnecessarily minting more when the initial
-        // "mintable amount" was perfect. So we map "mintable amount"s to "mint
-        // range"s below themselves by subtracting 1. Underflow avoided by the
-        // check for `minAmountOut == 0` at the start of the function.
-        uint256 ethAmount = _calculateDepositAmount(totalTVL, minAmountOut - 1, totalSupply);
-        if (ethAmount == 0) return (0, 0);
-        uint256 inflationPercentage = WAD * ethAmount / (totalTVL + ethAmount);
-
-        // Once we have the `inflationPercentage` mapping to the "mintable amount"
-        // below `minAmountOut`, we increment it to find the
-        // `inflationPercentage` mapping to the "mintable amount" above
-        // `minAmountOut".
-        ++inflationPercentage;
-
-        // Then we go on to calculate the ezETH amount and optimal eth deposit
-        // mapping to that `inflationPercentage`.
-
-        // Calculate the new supply
-        uint256 newEzETHSupply = (totalSupply * WAD) / (WAD - inflationPercentage);
-
-        amountOut = newEzETHSupply - totalSupply;
-
-        ethAmountIn = inflationPercentage.mulDiv(totalTVL, WAD - inflationPercentage, Math.Rounding.Ceil);
-
-        // Very rarely, the `inflationPercentage` is less by one. So we try both.
-        if (_calculateMintAmount(totalTVL, ethAmountIn, totalSupply) >= minAmountOut) return (ethAmountIn, amountOut);
-
-        ++inflationPercentage;
-        ethAmountIn = inflationPercentage.mulDiv(totalTVL, WAD - inflationPercentage, Math.Rounding.Ceil);
-
-        newEzETHSupply = (totalSupply * WAD) / (WAD - inflationPercentage);
-        amountOut = newEzETHSupply - totalSupply;
-
-        if (_calculateMintAmount(totalTVL, ethAmountIn, totalSupply) >= minAmountOut) return (ethAmountIn, amountOut);
-
+        amountOut = _calculateMintAmount(_currentValueInProtocol, _existingEzETHSupply, ethAmountIn);
+        if (amountOut >= minAmountOut) return (ethAmountIn, amountOut);
         revert InvalidAmountOut(ethAmountIn);
     }
 
@@ -183,12 +153,12 @@ library RenzoLibrary {
         (,, uint256 totalTVL) = RENZO_RESTAKE_MANAGER.calculateTVLs();
         uint256 totalSupply = EZETH.totalSupply();
 
-        amount = _calculateMintAmount(totalTVL, ethAmount, totalSupply);
-        optimalAmount = _calculateDepositAmount(totalTVL, amount, totalSupply);
+        amount = _calculateMintAmount(totalTVL, totalSupply, ethAmount);
+        optimalAmount = _calculateDepositAmount(totalTVL, totalSupply, amount);
 
         // Can be off by 1 wei
-        if (_calculateMintAmount(totalTVL, optimalAmount, totalSupply) == amount) return (amount, optimalAmount);
-        if (_calculateMintAmount(totalTVL, optimalAmount + 1, totalSupply) == amount) {
+        if (_calculateMintAmount(totalTVL, totalSupply, optimalAmount) == amount) return (amount, optimalAmount);
+        if (_calculateMintAmount(totalTVL, totalSupply, optimalAmount + 1) == amount) {
             return (amount, optimalAmount + 1);
         }
 
@@ -198,7 +168,7 @@ library RenzoLibrary {
     function depositForLrt(uint256 ethAmount) internal returns (uint256 ezEthAmountToMint) {
         (,, uint256 totalTVL) = RENZO_RESTAKE_MANAGER.calculateTVLs();
 
-        ezEthAmountToMint = _calculateMintAmount(totalTVL, ethAmount, EZETH.totalSupply());
+        ezEthAmountToMint = _calculateMintAmount(totalTVL, EZETH.totalSupply(), ethAmount);
         RENZO_RESTAKE_MANAGER.depositETH{ value: ethAmount }(0);
     }
 
@@ -210,13 +180,14 @@ library RenzoLibrary {
      * function properly, `amountOut` should be a "mintable amount" (an amount of
      * ezETH that is actually possible to mint).
      *
-     * @param totalTVL Total TVL in the system.
+     * @param _currentValueInProtocol Total TVL in the system.
+     * @param _existingEzETHSupply Total supply of ezETH.
      * @param amountOut Desired amount of ezETH to mint.
      */
     function _calculateDepositAmount(
-        uint256 totalTVL,
-        uint256 amountOut,
-        uint256 totalSupply
+        uint256 _currentValueInProtocol,
+        uint256 _existingEzETHSupply,
+        uint256 amountOut
     )
         private
         pure
@@ -227,28 +198,29 @@ library RenzoLibrary {
         //        uint256 mintAmount = newEzETHSupply - _existingEzETHSupply;
         //
         // Solve for newEzETHSupply
-        uint256 newEzEthSupply = (amountOut + totalSupply);
-        uint256 newEzEthSupplyRay = newEzEthSupply.scaleUpToRay(18);
+        uint256 newEzEthSupply = (amountOut + _existingEzETHSupply);
 
         //        uint256 newEzETHSupply = (_existingEzETHSupply * SCALE_FACTOR) / (SCALE_FACTOR -
         // inflationPercentage);
         //
         // Solve for inflationPercentage
-        uint256 intem = totalSupply.scaleUpToRay(18).mulDiv(RAY, newEzEthSupplyRay);
-        uint256 inflationPercentage = RAY - intem;
+        uint256 inflationPercentage = WAD - WAD.mulDiv(_existingEzETHSupply, newEzEthSupply);
 
         //         uint256 inflationPercentage = SCALE_FACTOR * _newValueAdded / (_currentValueInProtocol +
         // _newValueAdded);
         //
         // Solve for _newValueAdded
-        uint256 ethAmountRay = inflationPercentage.mulDiv(totalTVL.scaleUpToRay(18), RAY - inflationPercentage);
+        // NOTE This equation is intentionally rounded up. This is because if
+        // the division truncates and value is lost, the `ethAmountIn` in the
+        // forward compute will output less than the minimum `amountOut`. We
+        // round up to guarantee that the users will always only pay the minimum
+        // necessary amount for either the exact minimum amount out or the next
+        // closest possible mintable amount if the minimum amount out is not a
+        // mintable value.
+        uint256 ethAmountIn =
+            inflationPercentage.mulDiv(_currentValueInProtocol, WAD - inflationPercentage, Math.Rounding.Ceil);
 
-        // Truncate from RAY to WAD with roundingUp plus one extra
-        // The one extra to get into the next mint range
-        uint256 ethAmount = ethAmountRay / 1e9 + 1;
-        if (ethAmountRay % 1e9 != 0) ++ethAmount;
-
-        return ethAmount;
+        return ethAmountIn;
     }
 
     /**
@@ -264,8 +236,8 @@ library RenzoLibrary {
      */
     function _calculateMintAmount(
         uint256 _currentValueInProtocol,
-        uint256 _newValueAdded,
-        uint256 _existingEzETHSupply
+        uint256 _existingEzETHSupply,
+        uint256 _newValueAdded
     )
         private
         pure

--- a/test/fork/fuzz/lrt/RenzoLibrary.t.sol
+++ b/test/fork/fuzz/lrt/RenzoLibrary.t.sol
@@ -1,29 +1,412 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.21;
 
+import { WAD, RAY, WadRayMath } from "./../../../../src/libraries/math/WadRayMath.sol";
 import { RenzoLibrary } from "../../../../src/libraries/lrt/RenzoLibrary.sol";
 import { EZETH, RENZO_RESTAKE_MANAGER } from "../../../../src/Constants.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import { Test } from "forge-std/Test.sol";
+import { console2 } from "forge-std/console2.sol";
 
-import { safeconsole as console } from "forge-std/safeconsole.sol";
+using Math for uint256;
+using WadRayMath for uint256;
 
 uint256 constant SCALE_FACTOR = 1e18;
 
-contract RenzoLibrary_FuzzTest is Test {
+/**
+ * Used for comparing different backcompute methods.
+ */
+library OldRenzoLibrary {
+    error InvalidAmountOut(uint256 amountOut);
+    error InvalidAmountIn(uint256 amountIn);
+
+    function mockCalculateMintAmount(
+        uint256 _currentValueInProtocol,
+        uint256 _existingEzETHSupply,
+        uint256 _newValueAdded
+    )
+        public
+        pure
+        returns (uint256)
+    {
+        // For first mint, just return the new value added.
+        // Checking both current value and existing supply to guard against gaming the initial mint
+        if (_currentValueInProtocol == 0 || _existingEzETHSupply == 0) {
+            return _newValueAdded; // value is priced in base units, so divide by scale factor
+        }
+
+        // Calculate the percentage of value after the deposit
+        uint256 inflationPercentage = WAD * _newValueAdded / (_currentValueInProtocol + _newValueAdded);
+
+        // Calculate the new supply
+        uint256 newEzETHSupply = (_existingEzETHSupply * WAD) / (WAD - inflationPercentage);
+
+        // Subtract the old supply from the new supply to get the amount to mint
+        uint256 mintAmount = newEzETHSupply - _existingEzETHSupply;
+
+        return mintAmount;
+    }
+
+    function mockCalculateDepositAmount(
+        uint256 totalTVL,
+        uint256 totalSupply,
+        uint256 amountOut
+    )
+        public
+        pure
+        returns (uint256)
+    {
+        if (amountOut == 0) return 0;
+
+        //        uint256 mintAmount = newEzETHSupply - _existingEzETHSupply;
+        //
+        // Solve for newEzETHSupply
+        uint256 newEzEthSupply = (amountOut + totalSupply);
+        console2.log("newEzEthSupply: ", newEzEthSupply);
+        uint256 newEzEthSupplyRay = newEzEthSupply.scaleUpToRay(18);
+
+        //        uint256 newEzETHSupply = (_existingEzETHSupply * SCALE_FACTOR) / (SCALE_FACTOR -
+        // inflationPercentage);
+        //
+        // Solve for inflationPercentage
+        uint256 intem = totalSupply.scaleUpToRay(18).mulDiv(RAY, newEzEthSupplyRay);
+        uint256 inflationPercentage = RAY - intem;
+
+        //         uint256 inflationPercentage = SCALE_FACTOR * _newValueAdded / (_currentValueInProtocol +
+        // _newValueAdded);
+        //
+        // Solve for _newValueAdded
+        uint256 ethAmountRay = inflationPercentage.mulDiv(totalTVL.scaleUpToRay(18), RAY - inflationPercentage);
+
+        // Truncate from RAY to WAD with roundingUp plus one extra
+        // The one extra to get into the next mint range
+        uint256 ethAmount = ethAmountRay / 1e9 + 1;
+        if (ethAmountRay % 1e9 != 0) ++ethAmount;
+
+        return ethAmount;
+    }
+
+    // current math but with configurable totalTVL and totalSupply
+    function mockGetEthAmountInForLstAmountOut(
+        uint256 totalTVL,
+        uint256 totalSupply,
+        uint256 minAmountOut
+    )
+        public
+        view
+        returns (uint256 ethAmountIn, uint256 amountOut)
+    {
+        if (minAmountOut == 0) return (0, 0);
+
+        // passed in as params
+        // (,, uint256 totalTVL) = RENZO_RESTAKE_MANAGER.calculateTVLs();
+        // uint256 totalSupply = EZETH.totalSupply();
+
+        uint256 ethAmount = mockCalculateDepositAmount(totalTVL, totalSupply, minAmountOut - 1);
+        console2.log("first calculated ethAmount: ", ethAmount);
+        if (ethAmount == 0) return (0, 0);
+        uint256 inflationPercentage = WAD * ethAmount / (totalTVL + ethAmount);
+
+        // Once we have the `inflationPercentage` mapping to the "mintable amount"
+        // below `minAmountOut`, we increment it to find the
+        // `inflationPercentage` mapping to the "mintable amount" above
+        // `minAmountOut".
+        ++inflationPercentage;
+
+        // Then we go on to calculate the ezETH amount and optimal eth deposit
+        // mapping to that `inflationPercentage`.
+
+        // Calculate the new supply
+        uint256 newEzETHSupply = (totalSupply * WAD) / (WAD - inflationPercentage);
+
+        amountOut = newEzETHSupply - totalSupply;
+
+        ethAmountIn = inflationPercentage.mulDiv(totalTVL, WAD - inflationPercentage, Math.Rounding.Ceil);
+        console2.log("second calculated ethAmountIn: ", ethAmountIn);
+        // Very rarely, the `inflationPercentage` is less by one. So we try both.
+        if (mockCalculateMintAmount(totalTVL, totalSupply, ethAmountIn) >= minAmountOut) {
+            return (ethAmountIn, amountOut);
+        }
+
+        ++inflationPercentage;
+        ethAmountIn = inflationPercentage.mulDiv(totalTVL, WAD - inflationPercentage, Math.Rounding.Ceil);
+
+        newEzETHSupply = (totalSupply * WAD) / (WAD - inflationPercentage);
+        amountOut = newEzETHSupply - totalSupply;
+
+        if (mockCalculateMintAmount(totalTVL, totalSupply, ethAmountIn) >= minAmountOut) {
+            return (ethAmountIn, amountOut);
+        }
+
+        revert InvalidAmountOut(ethAmountIn);
+    }
+}
+
+contract RenzoLibraryHelper {
+    /**
+     * Copy of the private _calculateMintAmount function in RenzoLibrary.sol
+     */
+    function forwardCompute(
+        uint256 _existingEzETHSupply,
+        uint256 _currentValueInProtocol,
+        uint256 ethAmountIn
+    )
+        internal
+        pure
+        returns (uint256 mintAmount)
+    {
+        uint256 inflationPercentage = SCALE_FACTOR * ethAmountIn / (_currentValueInProtocol + ethAmountIn);
+        uint256 newEzETHSupply = (_existingEzETHSupply * SCALE_FACTOR) / (SCALE_FACTOR - inflationPercentage);
+        mintAmount = newEzETHSupply - _existingEzETHSupply;
+    }
+
+    /**
+     * Copy of the private _calculateDepositAmount function in RenzoLibrary.sol
+     */
+    function backCompute(
+        uint256 _existingEzETHSupply,
+        uint256 _currentValueInProtocol,
+        uint256 mintAmount
+    )
+        internal
+        pure
+        returns (uint256)
+    {
+        if (mintAmount == 0) return 0;
+
+        uint256 newEzETHSupply = mintAmount + _existingEzETHSupply;
+
+        uint256 inflationPercentage = SCALE_FACTOR - ((SCALE_FACTOR * _existingEzETHSupply) / newEzETHSupply);
+
+        uint256 ethAmountIn = inflationPercentage * _currentValueInProtocol / (SCALE_FACTOR - inflationPercentage);
+
+        if (inflationPercentage * _currentValueInProtocol % (SCALE_FACTOR - inflationPercentage) != 0) {
+            ethAmountIn++;
+        }
+
+        return ethAmountIn;
+    }
+}
+
+contract RenzoLibrary_Comparison_FuzzTest is RenzoLibraryHelper, Test {
+    function setUp() public { }
+
+    /**
+     * Compare which method has a lower dust bound.
+     * Compare which method has a lower ethAmountIn.
+     * Old method dust is always greater than the new method dust.
+     * Out of 10000 runs,
+     * - 9576 runs have equal ethAmountIn.
+     * - 420 runs have old method ethAmountIn greater than new method ethAmountIn.
+     * - 2 runs have old method ethAmountIn less than new method ethAmountIn.
+     */
+    function testFuzz_BackComputeComparison(
+        uint256 _existingEzETHSupply,
+        uint128 minMintAmount,
+        uint256 exchangeRate
+    )
+        public
+    {
+        uint256 maxExistingEzETHSupply = 120_000_000e18;
+
+        _existingEzETHSupply = bound(_existingEzETHSupply, 1e18, maxExistingEzETHSupply);
+
+        exchangeRate = bound(exchangeRate, 1e18, 3e18);
+
+        uint256 _currentValueInProtocol = _existingEzETHSupply * exchangeRate / 1e18; // backed 1:1
+
+        minMintAmount = uint128(bound(uint256(minMintAmount), 1e9, _existingEzETHSupply));
+
+        (uint256 oldMethodEthAmountIn, uint256 actualLrtAmount) = OldRenzoLibrary.mockGetEthAmountInForLstAmountOut(
+            _currentValueInProtocol, _existingEzETHSupply, minMintAmount
+        );
+
+        uint256 newMethodEthAmountIn = backCompute(_existingEzETHSupply, _currentValueInProtocol, minMintAmount);
+
+        uint256 oldMethodActualMintAmountOut =
+            forwardCompute(_existingEzETHSupply, _currentValueInProtocol, oldMethodEthAmountIn);
+        uint256 newMethodActualMintAmountOut =
+            forwardCompute(_existingEzETHSupply, _currentValueInProtocol, newMethodEthAmountIn);
+
+        vm.assume(oldMethodActualMintAmountOut != 0);
+        vm.assume(newMethodActualMintAmountOut != 0);
+
+        assertGe(
+            oldMethodActualMintAmountOut,
+            newMethodActualMintAmountOut,
+            "old method mint amount out is greater than or equal to new method mint amount out"
+        );
+
+        assertApproxEqAbs(oldMethodEthAmountIn, newMethodEthAmountIn, 1e8, "eth amount in approx eq");
+
+        uint256 oldMethodDust = oldMethodActualMintAmountOut - minMintAmount;
+        uint256 newMethodDust = newMethodActualMintAmountOut - minMintAmount;
+
+        assertGe(oldMethodDust, newMethodDust, "old method dust is greater than or equal to new method dust");
+        assertLe(oldMethodDust - newMethodDust, 1e9, "dust differential bound");
+
+        assertLe(newMethodDust, 1e9, "gwei bound"); // depends heavily on `maxExistingEzETHSupply`
+    }
+}
+
+contract RenzoLibrary_FuzzTest is RenzoLibraryHelper, Test {
+    /**
+     * -- Observations ---
+     * Max _existingEzETHSupply 10Me18 ($30B)
+     * _currentValueInProtocol = _existingEzETHSupply
+     * Max mintAmount _existingEzETHSupply / 2
+     * New Method: 1.75e7 fail, 1e8 pass
+     * Old Method: 1.75e7 fail, 1e8 pass
+     *
+     * Max _existingEzETHSupply 10Me19 (26 zeroes)
+     * 1e8 fails, 1e9 passes (9 zeroes)
+     *
+     * Max _existingEzETHSupply 10Me20 (27 zeroes)
+     * 1e9 fails, 1e10 passes (10 zeroes)
+     *
+     * Max _existingEzETHSupply 10Me21
+     * 1e10 fails, 1e11 passes
+     *
+     * Max _existingEzETHSuppply 10Me27
+     * 1e16 fails, 1e17 passes
+     *
+     * No proof, but max dust goes up 10x as the _existingEzETHSupply goes up 10x.
+     *
+     * Q: What happens when the Max _existingEzETHSupply increases?
+     * A: With all else equal, the dust increases.
+     *
+     * Q: What happens when the minMintAmount relative to _existingEzETHSupply increases?
+     * A: With all else equal, if there is no bound, or if the bound is 100x the existing supply, dust increases
+     *
+     * Q: What happens when the exchangeRate between ezETH and underlying increases?
+     * A: Even with very large exchange rates such as 10e18, the dust bound is not affected.
+     */
+    function testFuzz_BackComputeDustBound(uint256 _existingEzETHSupply, uint128 minMintAmount) public {
+        uint256 maxExistingEzETHSupply = 10_000_000e21;
+        _existingEzETHSupply = bound(_existingEzETHSupply, 1, maxExistingEzETHSupply);
+
+        uint256 _currentValueInProtocol = _existingEzETHSupply * 1.2e18 / 1e18; // backed 1.2:1
+
+        minMintAmount = uint128(bound(uint256(minMintAmount), 0, _existingEzETHSupply / 2));
+
+        uint256 ethAmountIn = backCompute(_currentValueInProtocol, _existingEzETHSupply, minMintAmount);
+        uint256 actualMintAmountOut = forwardCompute(_currentValueInProtocol, _existingEzETHSupply, ethAmountIn);
+
+        vm.assume(actualMintAmountOut != 0);
+        assertGe(actualMintAmountOut, minMintAmount, "amount out comparison");
+
+        assertLe(actualMintAmountOut - minMintAmount, 1e11, "gwei bound");
+    }
+
+    /**
+     * _existingEzETHSupply / 10**17 bound passes with:
+     * - _existingEzETHSupply [1e18, type(uint128).max]
+     * - exchangeRate [1e18, 8e18]
+     * - minMintAmount [0, _existingEzETHSupply]
+     */
+    function testFuzz_BackComputeFormulaicDustBound(
+        uint256 _existingEzETHSupply,
+        uint128 minMintAmount,
+        uint128 exchangeRate
+    )
+        public
+    {
+        _existingEzETHSupply = bound(_existingEzETHSupply, WAD, type(uint128).max);
+
+        exchangeRate = uint128(bound(exchangeRate, 1e18, 8e18)); // 9e18 fails
+
+        uint256 _currentValueInProtocol = _existingEzETHSupply * exchangeRate / 1e18;
+
+        minMintAmount = uint128(bound(uint256(minMintAmount), 0, _existingEzETHSupply));
+
+        uint256 ethAmountIn = backCompute(_currentValueInProtocol, _existingEzETHSupply, minMintAmount);
+        uint256 actualMintAmountOut = forwardCompute(_currentValueInProtocol, _existingEzETHSupply, ethAmountIn);
+
+        uint256 dustBound = _existingEzETHSupply / 10 ** 17;
+
+        vm.assume(actualMintAmountOut != 0);
+
+        assertGe(actualMintAmountOut, minMintAmount, "amount out comparison");
+
+        assertLe(actualMintAmountOut - minMintAmount, dustBound, "exact dust bound");
+    }
+
+    function testFuzz_BackComputeRealisticDustBound(
+        uint256 _existingEzETHSupply,
+        uint128 minMintAmount,
+        uint128 exchangeRate
+    )
+        public
+    {
+        // There are 120M circulating ETH as of 4/9/2024.
+        _existingEzETHSupply = bound(_existingEzETHSupply, WAD, 120_000_000e18);
+        // realistically, the exchangeRate will not more than triple
+        exchangeRate = uint128(bound(exchangeRate, 1e18, 3e18));
+        // realistically, a single mint would not be double the entire supply
+        minMintAmount = uint128(bound(uint256(minMintAmount), 0, _existingEzETHSupply * 2));
+
+        uint256 _currentValueInProtocol = _existingEzETHSupply * exchangeRate / 1e18;
+
+        uint256 ethAmountIn = backCompute(_currentValueInProtocol, _existingEzETHSupply, minMintAmount);
+        uint256 actualMintAmountOut = forwardCompute(_currentValueInProtocol, _existingEzETHSupply, ethAmountIn);
+
+        uint256 dustBound = 1e10;
+
+        vm.assume(actualMintAmountOut != 0);
+
+        assertGe(actualMintAmountOut, minMintAmount, "amount out comparison");
+        assertLe(actualMintAmountOut - minMintAmount, dustBound, "exact dust bound");
+    }
+
+    function testFuzz_BackComputeResultIsOptimal(
+        uint256 _existingEzETHSupply,
+        uint128 minMintAmount,
+        uint128 exchangeRate
+    )
+        public
+    {
+        uint256 maxExistingEzETHSupply = 10_000_000e18;
+
+        _existingEzETHSupply = bound(_existingEzETHSupply, 1, maxExistingEzETHSupply);
+        exchangeRate = uint128(bound(exchangeRate, 1e18, 2e18));
+        minMintAmount = uint128(bound(uint256(minMintAmount), 0, _existingEzETHSupply));
+
+        uint256 _currentValueInProtocol = _existingEzETHSupply * exchangeRate / 1e18;
+
+        uint256 ethAmountIn = backCompute(_currentValueInProtocol, _existingEzETHSupply, minMintAmount);
+        uint256 actualMintAmountOut = forwardCompute(_currentValueInProtocol, _existingEzETHSupply, ethAmountIn);
+
+        vm.assume(ethAmountIn != 0);
+
+        // try minting with one less
+        uint256 mintAmountOutWithOneLess =
+            forwardCompute(_currentValueInProtocol, _existingEzETHSupply, ethAmountIn - 1);
+
+        assertLe(mintAmountOutWithOneLess, minMintAmount, "one less eth amount comopared to min mint amount");
+        assertLe(mintAmountOutWithOneLess, actualMintAmountOut, "one less eth amount compared to actual mint amount");
+
+        vm.assume(actualMintAmountOut != 0);
+        assertGe(actualMintAmountOut, minMintAmount, "amount out comparison");
+
+        assertLe(actualMintAmountOut - minMintAmount, 1e11, "gwei bound");
+    }
+}
+
+contract RenzoLibrary_ForkFuzzTest is RenzoLibraryHelper, Test {
     function setUp() public {
         // vm.createSelectFork(vm.envString("MAINNET_RPC_URL"), 19387902);
-        vm.createSelectFork(vm.envString("MAINNET_RPC_URL"));
+        vm.createSelectFork(vm.envString("MAINNET_ARCHIVE_RPC_URL"));
     }
 
     function test_GetEthAmountInForLstAmountOut() public {
-        vm.createSelectFork(vm.envString("MAINNET_RPC_URL"), 19_472_376);
+        vm.createSelectFork(vm.envString("MAINNET_ARCHIVE_RPC_URL"), 19_472_376);
         uint128 minLrtAmount = 184_626_086_978_191_358;
         testForkFuzz_GetEthAmountInForLstAmountOut(minLrtAmount);
     }
 
     function test_GetLstAmountOutForEthAmountIn() public {
-        vm.createSelectFork(vm.envString("MAINNET_RPC_URL"), 19_472_376);
+        vm.createSelectFork(vm.envString("MAINNET_ARCHIVE_RPC_URL"), 19_472_376);
         uint128 ethAmount = 185_854_388_659_820_839;
         testForkFuzz_GetLstAmountOutForEthAmountIn(ethAmount);
     }
@@ -39,6 +422,19 @@ contract RenzoLibrary_FuzzTest is Test {
         vm.deal(address(this), ethAmount);
         RenzoLibrary.depositForLrt(ethAmount);
         assertEq(EZETH.balanceOf(address(this)), actualLrtAmount, "ezETH balance");
+    }
+
+    function testForkFuzz_GetEthAmountInForLstAmountOutWithDustBound(uint128 minLrtAmount) public {
+        uint256 _existingEzETHSupply = EZETH.totalSupply();
+        minLrtAmount = uint128(bound(uint256(minLrtAmount), 1, _existingEzETHSupply));
+
+        (uint256 ethAmount, uint256 actualLrtAmount) = RenzoLibrary.getEthAmountInForLstAmountOut(minLrtAmount);
+        assertGe(actualLrtAmount, minLrtAmount, "actualLrtAmount");
+
+        uint256 mintAmount = _calculateMintAmount(ethAmount);
+        vm.assume(mintAmount != 0);
+
+        assertLe(mintAmount - minLrtAmount, 1e8, "hard coded dust bound");
     }
 
     function testForkFuzz_GetLstAmountOutForEthAmountIn(uint128 ethAmount) public {
@@ -58,6 +454,15 @@ contract RenzoLibrary_FuzzTest is Test {
         vm.deal(address(this), ethAmount);
         RenzoLibrary.depositForLrt(ethAmount);
         assertEq(EZETH.balanceOf(address(this)), lrtAmountOut);
+    }
+
+    /**
+     * The optimal amount outputted from this function should always be less
+     * than the original input amount.
+     */
+    function testForkFuzz_GetLstAmountOutForEthAmountInOptimalAmount(uint128 ethAmount) public {
+        (uint256 amount, uint256 optimalAmount) = RenzoLibrary.getLstAmountOutForEthAmountIn(ethAmount);
+        assertLe(optimalAmount, ethAmount, "optimalAmount");
     }
 
     function _calculateMintAmount(uint256 ethAmount) internal view returns (uint256 mintAmount) {


### PR DESCRIPTION
## TODOs
### OZ
- [x] ezETH Library Changes

## ezETH Library Changes
The main problem is that due to multiple truncating divisions, there may be a broad range of `ethAmountIn` that leads to the same`mintAmountOut`. There are two goals to the ezETH library with regards to handling this rounding error induced by the Renzo math.
1. Minimize cost for users by allowing them to reach the desired `mintAmountOut` at the lowest possible `ethAmountIn`. 
2. Minimize the difference between the desired mint amount and the actual mint amount, minimizing the difference in expected and actual deposit amount. 

### Old Method vs. New Method Comparison 
- The old method refers to the `getEthAmountInForLstAmountOut` function that this PR modifies, which began by calculating the `ethAmountIn` with `mintAmountOut - 1`, and subsequently incrementing the `inflationPercentage`. 
- The new method refers to the `getEthAmountInForLstAmountOut` function in this PR, which does a simple backcompute, and rounds up the final `ethAmountIn`. 
- Although we show things empirically via fuzz, we do not yet have a formal theoretical understanding of the rounding behavior, so we resort to observations to make this decision. 

#### 1. Changes in the dust bound [Old vs. New] 
- Fuzz Setup
    - `_existingEzETHSupply` bounded between `[1e18, 120Me18]` (120Me18 being an absurdly high existing ezETH supply). 
    - `exchangeRate` bounded between `[1e18, 3e18]`. 
    - `minMintAmount` bounded between `[1e9, _existingEzETHSupply]` (Assumes that no one mint amount is greater than the entire supply). 
- Observations
    - The old method dust is always greater than new method dust 
    - The difference between the old method dust and the new method dust bound is approximately 1e9. 
    - Out of 100K runs, 
        - 148 runs had `old method dust < new method dust`. 
        - 2329 runs had `old method dust > new method dust`
        - 97523 runs had `old method dust == new method dust`
- Summary
    - Most of the times, the two methods were equal, but the new method reduced the dust amount in ~2% of the overall runs. 
        
#### 2. Changes in the `ethAmountIn` [Old vs. New] 
- The goal is to minimize the `ethAmountIn` while minting at least the minimum amount out. 
- Observations
  - Out of 10K fuzz results, 
      - 9576 runs resulted in equal ethAmountIn’s 
      - 420 runs resulted in old method ethAmountIn greater than new method ethAmountIn
      - 2 runs resulted in old method ethAountIn less than new method ethAmountIn 
  - Out of 100K fuzz 
      - 156 runs had `old method ethAmountIn < new method ethAmountIn`
      - 2400 runs had `old method ethAmountIn > new method ethAmountIn`
      - 97444 runs had `old method ethAmountIn == new method ethAmountIn`
- Summary 
    - Again, most of the times, the two methods were equal, but the new method more frequently minimized the `ethAmountIn`. 
      
### New Method Fuzz
      
#### 1. Is the new backcompute always optimal for users? 
- We consider the ethAmountIn to be optimal "if one less than the ethAmountIn would have resulted in a mintAmount less than the minimum amount out."
- Out of 100K fuzz results
    - The output of `ethAmountIn - 1` was always strictly less than the output of `ethAmountIn`, showing that this `ethAmountIn` was optimal. 
      
#### 2. Is there an exact maximum dust bound? 
- We still don’t have a theoretical bound to the maximum amount of dust that can be greated given the user input and known variables. This fuzz sets out some guarantees at ‘realistic’ worst-case values. 
- Fuzz Setup 
    - Max bound for existingEzETH fuzzed assuming all circulating ETH turns to ezETH. ~120Me18 tokens. 
    - The exchangeRate will most likely not exceed 2e18 (doubling value through staking yield). 
    - The incoming mint amount being less than double the entire supply of ezETH (impossible since we are also assuming that ). 
- Observations 
    - Even fuzzed with these extreme max bounds, the max dust does not exceed 1e9. 

### Conclusion
1. With the fuzz, we can see that the `ethAmountIn` is optimal. 
2. There is no formulaic bound on max dust, but there is a realistic-worst-case bound. 
The new method simplifies logic and is shown to lower cost for users (with smaller ethAmountIn) and with lower dust (which doesn’t affect ‘cost’ as the dust gets deposited into user vaults, but reduces the non-exact behavior of the contract). 