### PR TITLE
OZ Fix: L-01 and Informationals

### DIFF
--- a/src/flash/UniswapFlashswapDirectMintHandlerWithDust.sol
+++ b/src/flash/UniswapFlashswapDirectMintHandlerWithDust.sol
@@ -10,7 +10,6 @@ import { IUniswapV3SwapCallback } from "@uniswap/v3-core/contracts/interfaces/ca
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { console2 } from "forge-std/console2.sol";
 
 /**
  * @notice This contract is forked off of the UniswapFlashswapDirectMintHandler,
@@ -28,7 +27,7 @@ import { console2 } from "forge-std/console2.sol";
  * of initial user deposit and additionally minted collateral to the caller's
  * requested resulting additional collateral amount.
  *
- * This contract allows for easy creation of leverge positions through a Uniswap
+ * This contract allows for easy creation of leverage positions through a Uniswap
  * flashswap and direct mint of the collateral from the provider. This will be
  * used when the collateral cannot be minted directly with the base asset but
  * can be directly minted by a token that the base asset has a UniswapV3 pool
@@ -94,6 +93,7 @@ abstract contract UniswapFlashswapDirectMintHandlerWithDust is IonHandlerBase, I
      * @param initialDeposit in collateral terms. [WAD]
      * @param resultingAdditionalCollateral in collateral terms. [WAD]
      * @param maxResultingDebt in base asset terms. [WAD]
+     * @param deadline The unix timestamp after which the uniswap transaction reverts.
      * @param proof used to validate the user is whitelisted.
      */
     function flashswapAndMint(

--- a/src/flash/lrt/EzEthHandler.sol
+++ b/src/flash/lrt/EzEthHandler.sol
@@ -7,7 +7,7 @@ import { Whitelist } from "../../Whitelist.sol";
 import { UniswapFlashswapDirectMintHandlerWithDust } from "./../UniswapFlashswapDirectMintHandlerWithDust.sol";
 import { IonHandlerBase } from "../IonHandlerBase.sol";
 import { RenzoLibrary } from "./../../libraries/lrt/RenzoLibrary.sol";
-import { EZETH, WETH_ADDRESS } from "../../Constants.sol";
+import { WETH_ADDRESS } from "../../Constants.sol";
 
 import { IUniswapV3Pool } from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 

--- a/src/libraries/lrt/KelpDaoLibrary.sol
+++ b/src/libraries/lrt/KelpDaoLibrary.sol
@@ -14,6 +14,8 @@ using Math for uint256;
  * @title KelpDaoLibrary
  *
  * @notice A helper library for KelpDao-related conversions.
+ *
+ * @custom:security-contact security@molecularlabs.io
  */
 library KelpDaoLibrary {
     /**

--- a/src/libraries/lrt/RenzoLibrary.sol
+++ b/src/libraries/lrt/RenzoLibrary.sol
@@ -75,6 +75,8 @@ using WadRayMath for uint256;
  * We will call the range of values that produce the same amount of ezETH a
  * "mint range". The mint range for `0` ezETH is `0` to `227527` wei and the mint
  * range for `226219` ezETH is `227528` to `455054` wei.
+ *
+ * @custom:security-contact security@molecularlabs.io
  */
 
 library RenzoLibrary {

--- a/src/libraries/lrt/RenzoLibrary.sol
+++ b/src/libraries/lrt/RenzoLibrary.sol
@@ -2,13 +2,12 @@
 pragma solidity 0.8.21;
 
 import { RENZO_RESTAKE_MANAGER, EZETH } from "../../Constants.sol";
-import { WadRayMath, WAD, RAY } from "../math/WadRayMath.sol";
+import { WadRayMath, WAD } from "../math/WadRayMath.sol";
 
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 using Math for uint256;
 using WadRayMath for uint256;
-
 /**
  * @title RenzoLibrary
  *
@@ -77,6 +76,7 @@ using WadRayMath for uint256;
  * "mint range". The mint range for `0` ezETH is `0` to `227527` wei and the mint
  * range for `226219` ezETH is `227528` to `455054` wei.
  */
+
 library RenzoLibrary {
     error InvalidAmountOut(uint256 amountOut);
     error InvalidAmountIn(uint256 amountIn);

--- a/src/oracles/spot/lrt/EzEthWstEthSpotOracle.sol
+++ b/src/oracles/spot/lrt/EzEthWstEthSpotOracle.sol
@@ -41,6 +41,9 @@ contract EzEthWstEthSpotOracle is SpotOracle {
     /**
      * @notice Gets the price of ezETH in wstETH
      * (ETH / ezETH) / (ETH / stETH) * (wstETH / stETH) = wstETH / ezETH
+     * @dev Redstone oracle returns ETH per ezETH with 8 decimals. This needs to
+     * be converted to wstETH per ezETH denomination.
+     * @return wstEthPerWeEth price of ezETH in wstETH. [WAD]
      */
     function getPrice() public view override returns (uint256) {
         // ETH / ezETH [8 decimals]

--- a/src/periphery/IonInvariants.sol
+++ b/src/periphery/IonInvariants.sol
@@ -7,6 +7,8 @@ import { WadRayMath } from "../libraries/math/WadRayMath.sol";
 /**
  * @notice This contract will be deployed on mainnet and be used to check the
  * invariants of the Ion system offchain every block.
+ *
+ * @custom:security-contact security@molecularlabs.io
  */
 contract IonInvariants {
     using WadRayMath for uint256;

--- a/test/fork/fuzz/handlers-base/UniswapFlashswapDirectMintHandlerWithDust.t.sol
+++ b/test/fork/fuzz/handlers-base/UniswapFlashswapDirectMintHandlerWithDust.t.sol
@@ -10,8 +10,6 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 using WadRayMath for uint256;
 
-import { console2 } from "forge-std/console2.sol";
-
 struct Config {
     uint256 initialDepositLowerBound;
 }
@@ -48,8 +46,7 @@ abstract contract UniswapFlashswapDirectMintHandlerWithDust_FuzzTest is LrtHandl
         uint256 roundingError = currentRate / RAY;
         if (currentRate % RAY != 0) roundingError++;
 
-        // TODO: Can this dust amount be bounded at run-time?
-        uint256 maxDust = 400_000;
+        uint256 maxDust = 1e9;
 
         assertLt(
             ionPool.collateral(_getIlkIndex(), address(this)),


### PR DESCRIPTION
- [x] `L-01` Incomplete Docstrings
    - Changes in `EzEthWstEthSpotOracle.sol` and `UniswapFlashswapDirectMintHandlerWithDust.sol`
- [x] `N-01` Incremental update in an unchecked blockwas is no longer necessary as the incremental update was removed in the PR that introduced rounding up to `ethAmountIn` in the `RenzoLibrary`. 
- [x] `N-02` Unused error `InvalidAmountIn` removed 
- [x] `N-04` Security contract to `RenzoLibrary.sol`
- [x] `N-06` Typo 