### PR TITLE
Resolving reverts in invariant tests

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -27,8 +27,9 @@ max_test_rejects = 655360
 [profile.default.invariant]
 runs = 20
 depth = 1536
-# fail_on_revert = true
+fail_on_revert = true
 call_override = false   # reentrancy-check
+preserve_state = true
 
 [profile.ci.fuzz]
 runs = 10


### PR DESCRIPTION
The issue with invariant tests reverting when `fail_on_revert` was set to true was due to calls to [vm.warp not preserving state between calls](https://github.com/foundry-rs/foundry/issues/6694). 

A workaround was added in [this](https://github.com/foundry-rs/foundry/pull/7219) PR to Foundry which added the `preserve_state` to the invariant section of the foundry config.

I've added this to the config and it resolves the issue when running `forge test --mc "IonPool_InvariantTest" -v`.

In the image below you can see that the invariant tests now run without reverting when `fail_on_revert=true`

<img width="932" alt="image" src="https://github.com/Ion-Protocol/ion-protocol/assets/94120714/f230c306-25b0-447f-9e40-90b9561cd3c8">