### PR TITLE
Core Upgrade: Revert to Rebasing

### DIFF
--- a/src/IonPool.sol
+++ b/src/IonPool.sol
@@ -364,7 +364,7 @@ contract IonPool is PausableUpgradeable, RewardToken {
     function _accrueInterest() internal returns (uint256 newTotalDebt) {
         IonPoolStorage storage $ = _getIonPoolStorage();
 
-        uint256 totalEthSupply = getTotalUnderlyingClaimsUnaccrued();
+        uint256 totalEthSupply = totalSupplyUnaccrued();
 
         uint256 totalSupplyFactorIncrease;
         uint256 totalTreasuryMintAmount;
@@ -419,7 +419,7 @@ contract IonPool is PausableUpgradeable, RewardToken {
         rateIncreases = new uint104[](ilksLength);
         timestampIncreases = new uint48[](ilksLength);
 
-        uint256 totalEthSupply = getTotalUnderlyingClaimsUnaccrued();
+        uint256 totalEthSupply = totalSupplyUnaccrued();
 
         for (uint8 i = 0; i < ilksLength;) {
             (
@@ -457,7 +457,7 @@ contract IonPool is PausableUpgradeable, RewardToken {
         returns (uint104 newRateIncrease, uint48 timestampIncrease)
     {
         (,, newRateIncrease,, timestampIncrease) =
-            _calculateRewardAndDebtDistributionForIlk(ilkIndex, getTotalUnderlyingClaimsUnaccrued());
+            _calculateRewardAndDebtDistributionForIlk(ilkIndex, totalSupplyUnaccrued());
     }
 
     function _calculateRewardAndDebtDistributionForIlk(
@@ -512,7 +512,7 @@ contract IonPool is PausableUpgradeable, RewardToken {
         newDebtIncrease = _totalNormalizedDebt * newRateIncrease; // [RAD]
 
         // Income distribution
-        uint256 _normalizedTotalSupply = totalSupplyUnaccrued(); // [WAD]
+        uint256 _normalizedTotalSupply = normalizedTotalSupplyUnaccrued(); // [WAD]
 
         // If there is no supply, then nothing is being lent out.
         supplyFactorIncrease = _normalizedTotalSupply == 0
@@ -570,7 +570,7 @@ contract IonPool is PausableUpgradeable, RewardToken {
 
         uint256 _supplyCap = $.supplyCap;
 
-        if (getTotalUnderlyingClaims() > _supplyCap) revert DepositSurpassesSupplyCap(amount, _supplyCap);
+        if (totalSupply() > _supplyCap) revert DepositSurpassesSupplyCap(amount, _supplyCap);
 
         emit Supply(user, _msgSender(), amount, _supplyFactor, newTotalDebt);
     }
@@ -954,7 +954,7 @@ contract IonPool is PausableUpgradeable, RewardToken {
     function getCurrentBorrowRate(uint8 ilkIndex) external view returns (uint256 borrowRate, uint256 reserveFactor) {
         IonPoolStorage storage $ = _getIonPoolStorage();
 
-        uint256 totalEthSupply = getTotalUnderlyingClaimsUnaccrued();
+        uint256 totalEthSupply = totalSupplyUnaccrued();
 
         uint256 _totalNormalizedDebt = $.ilks[ilkIndex].totalNormalizedDebt;
         uint256 _rate = $.ilks[ilkIndex].rate;

--- a/src/token/RewardToken.sol
+++ b/src/token/RewardToken.sol
@@ -453,7 +453,7 @@ abstract contract RewardToken is
      * @dev Current token balance
      * @param user to get balance of
      */
-    function getUnderlyingClaimOf(address user) public view returns (uint256) {
+    function balanceOf(address user) public view returns (uint256) {
         RewardTokenStorage storage $ = _getRewardTokenStorage();
 
         (uint256 totalSupplyFactorIncrease,,,,) = calculateRewardAndDebtDistribution();
@@ -465,7 +465,7 @@ abstract contract RewardToken is
      * @dev Accounting is done in normalized balances
      * @param user to get normalized balance of
      */
-    function balanceOf(address user) external view returns (uint256) {
+    function normalizedBalanceOf(address user) external view returns (uint256) {
         RewardTokenStorage storage $ = _getRewardTokenStorage();
         return $._normalizedBalances[user];
     }
@@ -494,7 +494,10 @@ abstract contract RewardToken is
         return $.treasury;
     }
 
-    function getTotalUnderlyingClaimsUnaccrued() public view returns (uint256) {
+    /**
+     * @dev Total claim of the underlying asset belonging to lenders not inclusive of the new interest to be accrued.
+     */
+    function totalSupplyUnaccrued() public view returns (uint256) {
         RewardTokenStorage storage $ = _getRewardTokenStorage();
 
         uint256 _normalizedTotalSupply = $.normalizedTotalSupply;
@@ -507,9 +510,9 @@ abstract contract RewardToken is
     }
 
     /**
-     * @dev Total claim of the underlying asset belonging to lenders.
+     * @dev Total claim of the underlying asset belonging to lender inclusive of the new interest to be accrued.
      */
-    function getTotalUnderlyingClaims() public view returns (uint256) {
+    function totalSupply() public view returns (uint256) {
         RewardTokenStorage storage $ = _getRewardTokenStorage();
 
         uint256 _normalizedTotalSupply = $.normalizedTotalSupply;
@@ -523,7 +526,7 @@ abstract contract RewardToken is
         return _normalizedTotalSupply.rayMulDown($.supplyFactor + totalSupplyFactorIncrease);
     }
 
-    function totalSupplyUnaccrued() public view returns (uint256) {
+    function normalizedTotalSupplyUnaccrued() public view returns (uint256) {
         RewardTokenStorage storage $ = _getRewardTokenStorage();
         return $.normalizedTotalSupply;
     }
@@ -533,7 +536,7 @@ abstract contract RewardToken is
      *
      * Normalized total supply and total supply are same in non-rebasing token.
      */
-    function totalSupply() public view returns (uint256) {
+    function normalizedTotalSupply() public view returns (uint256) {
         RewardTokenStorage storage $ = _getRewardTokenStorage();
 
         (uint256 totalSupplyFactorIncrease, uint256 totalTreasuryMintAmount,,,) = calculateRewardAndDebtDistribution();

--- a/test/fork/fuzz/lrt/EtherFiLibrary.t.sol
+++ b/test/fork/fuzz/lrt/EtherFiLibrary.t.sol
@@ -31,7 +31,7 @@ contract EtherFiLibrary_FuzzTest is Test {
 
     function testForkFuzz_GetLstAmountOutForEthAmountIn(uint256 ethAmount) external {
         vm.assume(ethAmount != 0);
-        vm.assume(ethAmount < type(uint128).max);
+        vm.assume(ethAmount < type(uint96).max);
 
         uint256 lrtAmountOut = EtherFiLibrary.getLstAmountOutForEthAmountIn(WEETH_ADDRESS, ethAmount);
 

--- a/test/integration/concrete/WeEthIonPool.t.sol
+++ b/test/integration/concrete/WeEthIonPool.t.sol
@@ -125,7 +125,7 @@ contract WeEthIonPool_IntegrationTest is WeEthIonPoolSharedSetup {
         ionPool.supply(lenderA, lenderAFirstSupplyAmount, lenderProofs[0]);
         vm.stopPrank();
 
-        assertEq(ionPool.getUnderlyingClaimOf(lenderA), lenderAFirstSupplyAmount, "lender balance after 1st supply");
+        assertEq(ionPool.balanceOf(lenderA), lenderAFirstSupplyAmount, "lender balance after 1st supply");
         assertEq(lens.liquidity(iIonPool), lenderAFirstSupplyAmount, "liquidity after 1st supply");
 
         /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -172,10 +172,7 @@ contract WeEthIonPool_IntegrationTest is WeEthIonPoolSharedSetup {
         uint256 roundingError = ionPool.supplyFactor() / 1e27;
 
         assertApproxEqAbs(
-            ionPool.getUnderlyingClaimOf(lenderB),
-            lenderBFirstSupplyAmount,
-            roundingError,
-            "lenderB balance after 1st supply"
+            ionPool.balanceOf(lenderB), lenderBFirstSupplyAmount, roundingError, "lenderB balance after 1st supply"
         );
 
         /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -219,14 +216,14 @@ contract WeEthIonPool_IntegrationTest is WeEthIonPoolSharedSetup {
         vm.startPrank(lenderA);
         ionPool.withdraw(lenderA, lender1WithdrawAmountFail);
 
-        uint256 lenderABalanceBefore = ionPool.getUnderlyingClaimOf(lenderA);
+        uint256 lenderABalanceBefore = ionPool.balanceOf(lenderA);
 
         uint256 lender1WithdrawAmount = 10e18;
         ionPool.withdraw(lenderA, lender1WithdrawAmount);
         vm.stopPrank();
 
         assertEq(
-            ionPool.getUnderlyingClaimOf(lenderA),
+            ionPool.balanceOf(lenderA),
             lenderABalanceBefore - lender1WithdrawAmount,
             "lenderA balance after 1st withdrawal"
         );

--- a/test/invariant/IonPool/ActorManager.t.sol
+++ b/test/invariant/IonPool/ActorManager.t.sol
@@ -227,7 +227,7 @@ contract IonPool_InvariantTest is IonPoolSharedSetup {
 
     function invariant_LenderDepositsAddToBalance() external returns (bool) {
         for (uint256 i = 0; i < lenders.length; i++) {
-            assertEq(lenders[i].totalHoldingsNormalized(), ionPool.balanceOf(address(lenders[i])));
+            assertEq(lenders[i].totalHoldingsNormalized(), ionPool.normalizedBalanceOf(address(lenders[i])));
         }
 
         return !failed();
@@ -236,9 +236,12 @@ contract IonPool_InvariantTest is IonPoolSharedSetup {
     function invariant_LenderBalancesPlusTreasuryAddToTotalSupply() external returns (bool) {
         uint256 totalLenderNormalizedBalances;
         for (uint256 i = 0; i < lenders.length; i++) {
-            totalLenderNormalizedBalances += ionPool.balanceOf(address(lenders[i]));
+            totalLenderNormalizedBalances += ionPool.normalizedBalanceOf(address(lenders[i]));
         }
-        assertEq(totalLenderNormalizedBalances + ionPool.balanceOf(TREASURY), ionPool.totalSupplyUnaccrued());
+        assertEq(
+            totalLenderNormalizedBalances + ionPool.normalizedBalanceOf(TREASURY),
+            ionPool.normalizedTotalSupplyUnaccrued()
+        );
 
         return !failed();
     }
@@ -256,7 +259,7 @@ contract IonPool_InvariantTest is IonPoolSharedSetup {
         assertGe(lens.liquidity(iIonPool) + totalDebt, ionPool.totalSupplyUnaccrued());
         assertGe(
             lens.liquidity(iIonPool).scaleUpToRad(18) + lens.debtUnaccrued(iIonPool),
-            ionPool.totalSupplyUnaccrued() * ionPool.supplyFactorUnaccrued()
+            ionPool.normalizedTotalSupplyUnaccrued() * ionPool.supplyFactorUnaccrued()
         );
 
         return !failed();

--- a/test/invariant/RewardToken/ActorManager.t.sol
+++ b/test/invariant/RewardToken/ActorManager.t.sol
@@ -105,20 +105,20 @@ contract RewardToken_InvariantTest is RewardTokenSharedSetup {
         uint256 totalSupplyByBalances;
         for (uint256 i = 0; i < userHandlers.length; i++) {
             UserHandler user = userHandlers[i];
-            totalSupplyByBalances += rewardModule.balanceOf(address(user));
+            totalSupplyByBalances += rewardModule.normalizedBalanceOf(address(user));
         }
 
         underlying.balanceOf(address(rewardModule)); // update underlying balance
         rewardModule.totalSupply();
 
-        assertEq(rewardModule.totalSupply(), totalSupplyByBalances);
+        assertEq(rewardModule.normalizedTotalSupply(), totalSupplyByBalances);
     }
 
     function invariant_lenderClaimAlwaysBacked() external {
-        uint256 lenderClaim = rewardModule.getTotalUnderlyingClaims();
+        uint256 totalSupply = rewardModule.totalSupply();
 
         uint256 underlyingBalance = underlying.balanceOf(address(rewardModule));
 
-        assertGe(underlyingBalance, lenderClaim);
+        assertGe(underlyingBalance, totalSupply);
     }
 }

--- a/test/invariant/RewardToken/Handlers.t.sol
+++ b/test/invariant/RewardToken/Handlers.t.sol
@@ -39,11 +39,11 @@ contract UserHandler is Handler {
     }
 
     function burn(address account, uint256 amount) external {
-        amount = bound(amount, 0, REWARD_MODULE.getUnderlyingClaimOf(account));
+        amount = bound(amount, 0, REWARD_MODULE.balanceOf(account));
         uint256 currentSupplyFactor = REWARD_MODULE.supplyFactor();
 
         uint256 amountNormalized = amount.rayDivUp(currentSupplyFactor);
-        if (amountNormalized == 0 || amountNormalized > REWARD_MODULE.balanceOf(account)) return;
+        if (amountNormalized == 0 || amountNormalized > REWARD_MODULE.normalizedBalanceOf(account)) return;
         REWARD_MODULE.burn(account, account, amount);
     }
 
@@ -66,11 +66,11 @@ contract SupplyFactorIncreaseHandler is Handler {
         uint256 oldSupplyFactor = REWARD_MODULE.supplyFactor();
         amount = bound(amount, 1.1e27, 1.25e27); // between 1E-16 and 15%
 
-        uint256 oldTotalSupply = REWARD_MODULE.getTotalUnderlyingClaims();
+        uint256 oldTotalSupply = REWARD_MODULE.totalSupply();
         uint256 newSupplyFactor = oldSupplyFactor.rayMulDown(amount);
         REWARD_MODULE.setSupplyFactor(newSupplyFactor);
 
-        uint256 interestCreated = REWARD_MODULE.getTotalUnderlyingClaims() - oldTotalSupply;
+        uint256 interestCreated = REWARD_MODULE.totalSupply() - oldTotalSupply;
         UNDERLYING.mint(address(REWARD_MODULE), interestCreated + 1);
     }
 }

--- a/test/unit/concrete/RewardToken.t.sol
+++ b/test/unit/concrete/RewardToken.t.sol
@@ -42,7 +42,7 @@ contract RewardToken_UnitTest is RewardTokenSharedSetup {
         rewardModule.mint(address(0), amountOfRewards);
         rewardModule.mint(address(this), amountOfRewards);
 
-        assertEq(rewardModule.balanceOf(address(this)), amountOfRewards);
+        assertEq(rewardModule.normalizedBalanceOf(address(this)), amountOfRewards);
         assertEq(underlying.balanceOf(address(this)), INITIAL_UNDERYLING - amountOfRewards);
         assertEq(underlying.balanceOf(address(rewardModule)), amountOfRewards);
     }
@@ -66,14 +66,14 @@ contract RewardToken_UnitTest is RewardTokenSharedSetup {
         underlying.approve(address(rewardModule), INITIAL_UNDERYLING);
         rewardModule.mint(address(this), amountOfRewards);
 
-        assertEq(rewardModule.balanceOf(address(this)), amountOfRewards);
+        assertEq(rewardModule.normalizedBalanceOf(address(this)), amountOfRewards);
         assertEq(underlying.balanceOf(address(this)), INITIAL_UNDERYLING - amountOfRewards);
 
         vm.expectRevert(abi.encodeWithSelector(RewardToken.InvalidSender.selector, address(0)));
         rewardModule.burn(address(0), address(this), amountOfRewards);
         rewardModule.burn(address(this), address(this), amountOfRewards);
 
-        assertEq(rewardModule.balanceOf(address(this)), 0);
+        assertEq(rewardModule.normalizedBalanceOf(address(this)), 0);
     }
 
     function test_MintRewardWithSupplyFactorChange() external {
@@ -85,8 +85,8 @@ contract RewardToken_UnitTest is RewardTokenSharedSetup {
 
         uint256 expectedNormalizedMint1 = amountOfRewards.rayDivDown(supplyFactorOld);
 
-        assertEq(rewardModule.balanceOf(address(this)), expectedNormalizedMint1);
-        assertEq(rewardModule.getUnderlyingClaimOf(address(this)), amountOfRewards);
+        assertEq(rewardModule.normalizedBalanceOf(address(this)), expectedNormalizedMint1);
+        assertEq(rewardModule.balanceOf(address(this)), amountOfRewards);
         assertEq(underlying.balanceOf(address(this)), INITIAL_UNDERYLING - amountOfRewards);
         assertEq(underlying.balanceOf(address(rewardModule)), amountOfRewards);
 
@@ -104,8 +104,8 @@ contract RewardToken_UnitTest is RewardTokenSharedSetup {
         uint256 totalDepositsNormalized = expectedNormalizedMint1 + expectedNormalizedMint2;
         uint256 totalValue = totalDepositsNormalized.rayMulDown(supplyFactorNew);
 
-        assertEq(rewardModule.balanceOf(address(this)), totalDepositsNormalized);
-        assertEq(rewardModule.getUnderlyingClaimOf(address(this)), totalValue);
+        assertEq(rewardModule.normalizedBalanceOf(address(this)), totalDepositsNormalized);
+        assertEq(rewardModule.balanceOf(address(this)), totalValue);
         assertEq(underlying.balanceOf(address(this)), INITIAL_UNDERYLING - totalDeposited);
         assertEq(underlying.balanceOf(address(rewardModule)), totalDeposited + interestCreated);
 
@@ -129,8 +129,8 @@ contract RewardToken_UnitTest is RewardTokenSharedSetup {
 
         uint256 expectedNormalizedMint1 = amountOfRewards.rayDivDown(supplyFactorOld);
 
-        assertEq(rewardModule.balanceOf(address(this)), expectedNormalizedMint1);
-        assertEq(rewardModule.getUnderlyingClaimOf(address(this)), amountOfRewards);
+        assertEq(rewardModule.normalizedBalanceOf(address(this)), expectedNormalizedMint1);
+        assertEq(rewardModule.balanceOf(address(this)), amountOfRewards);
         assertEq(underlying.balanceOf(address(this)), INITIAL_UNDERYLING - amountOfRewards);
         assertEq(underlying.balanceOf(address(rewardModule)), amountOfRewards);
 
@@ -148,8 +148,8 @@ contract RewardToken_UnitTest is RewardTokenSharedSetup {
         uint256 totalDepositsNormalized = expectedNormalizedMint1 + expectedNormalizedMint2;
         uint256 totalValue = totalDepositsNormalized.rayMulDown(supplyFactorNew);
 
-        assertEq(rewardModule.balanceOf(address(this)), totalDepositsNormalized);
-        assertEq(rewardModule.getUnderlyingClaimOf(address(this)), totalValue);
+        assertEq(rewardModule.normalizedBalanceOf(address(this)), totalDepositsNormalized);
+        assertEq(rewardModule.balanceOf(address(this)), totalValue);
         assertEq(underlying.balanceOf(address(this)), INITIAL_UNDERYLING - totalDeposited);
         assertEq(underlying.balanceOf(address(rewardModule)), totalDeposited + interestCreated);
 
@@ -174,9 +174,13 @@ contract RewardToken_UnitTest is RewardTokenSharedSetup {
 
         rewardModule.burn(address(this), address(this), burnAmount);
 
-        assertEq(rewardModule.getUnderlyingClaimOf(address(this)), totalValue - burnAmount);
-        assertEq(rewardModule.totalSupply(), totalDepositsNormalized - burnAmountNormalized, "total supply after burn");
-        assertEq(rewardModule.balanceOf(address(this)), totalDepositsNormalized - burnAmountNormalized);
+        assertEq(rewardModule.balanceOf(address(this)), totalValue - burnAmount);
+        assertEq(
+            rewardModule.normalizedTotalSupply(),
+            totalDepositsNormalized - burnAmountNormalized,
+            "total supply after burn"
+        );
+        assertEq(rewardModule.normalizedBalanceOf(address(this)), totalDepositsNormalized - burnAmountNormalized);
         assertEq(underlying.balanceOf(address(this)), INITIAL_UNDERYLING - totalDeposited + burnAmount);
         assertEq(underlying.balanceOf(address(rewardModule)), totalDeposited + interestCreated - burnAmount);
     }
@@ -187,7 +191,7 @@ contract RewardToken_UnitTest is RewardTokenSharedSetup {
         underlying.approve(address(rewardModule), INITIAL_UNDERYLING);
         rewardModule.mint(address(this), amountOfRewardTokens);
 
-        assertEq(rewardModule.balanceOf(address(this)), amountOfRewardTokens);
+        assertEq(rewardModule.normalizedBalanceOf(address(this)), amountOfRewardTokens);
         assertEq(underlying.balanceOf(address(this)), INITIAL_UNDERYLING - amountOfRewardTokens);
         assertEq(underlying.balanceOf(address(rewardModule)), amountOfRewardTokens);
 
@@ -206,8 +210,8 @@ contract RewardToken_UnitTest is RewardTokenSharedSetup {
         rewardModule.transfer(address(this), amountOfRewardTokens);
         rewardModule.transfer(receivingUser, amountOfRewardTokens);
 
-        assertEq(rewardModule.balanceOf(address(this)), 0);
-        assertEq(rewardModule.balanceOf(receivingUser), amountOfRewardTokens);
+        assertEq(rewardModule.normalizedBalanceOf(address(this)), 0);
+        assertEq(rewardModule.normalizedBalanceOf(receivingUser), amountOfRewardTokens);
         assertEq(underlying.balanceOf(address(this)), INITIAL_UNDERYLING - amountOfRewardTokens);
     }
 
@@ -217,8 +221,8 @@ contract RewardToken_UnitTest is RewardTokenSharedSetup {
         underlying.approve(address(rewardModule), INITIAL_UNDERYLING);
         rewardModule.mint(sendingUser, amountOfRewardTokens);
 
-        assertEq(rewardModule.balanceOf(sendingUser), amountOfRewardTokens);
-        assertEq(rewardModule.balanceOf(receivingUser), 0);
+        assertEq(rewardModule.normalizedBalanceOf(sendingUser), amountOfRewardTokens);
+        assertEq(rewardModule.normalizedBalanceOf(receivingUser), 0);
         assertEq(rewardModule.allowance(sendingUser, spender), 0);
         assertEq(underlying.balanceOf(address(this)), INITIAL_UNDERYLING - amountOfRewardTokens);
         assertEq(underlying.balanceOf(address(rewardModule)), amountOfRewardTokens);
@@ -246,8 +250,8 @@ contract RewardToken_UnitTest is RewardTokenSharedSetup {
         rewardModule.transferFrom(sendingUser, receivingUser, amountOfRewardTokens + 1);
         rewardModule.transferFrom(sendingUser, receivingUser, amountOfRewardTokens);
 
-        assertEq(rewardModule.balanceOf(sendingUser), 0);
-        assertEq(rewardModule.balanceOf(receivingUser), amountOfRewardTokens);
+        assertEq(rewardModule.normalizedBalanceOf(sendingUser), 0);
+        assertEq(rewardModule.normalizedBalanceOf(receivingUser), amountOfRewardTokens);
         assertEq(rewardModule.allowance(sendingUser, spender), 0);
     }
 
@@ -257,8 +261,8 @@ contract RewardToken_UnitTest is RewardTokenSharedSetup {
         underlying.approve(address(rewardModule), INITIAL_UNDERYLING);
         rewardModule.mint(sendingUser, amountOfRewardTokens);
 
-        assertEq(rewardModule.balanceOf(sendingUser), amountOfRewardTokens);
-        assertEq(rewardModule.balanceOf(receivingUser), 0);
+        assertEq(rewardModule.normalizedBalanceOf(sendingUser), amountOfRewardTokens);
+        assertEq(rewardModule.normalizedBalanceOf(receivingUser), 0);
         assertEq(rewardModule.allowance(sendingUser, spender), 0);
         assertEq(underlying.balanceOf(address(this)), INITIAL_UNDERYLING - amountOfRewardTokens);
         assertEq(underlying.balanceOf(address(rewardModule)), amountOfRewardTokens);
@@ -307,8 +311,8 @@ contract RewardToken_UnitTest is RewardTokenSharedSetup {
         rewardModule.transferFrom(sendingUser, receivingUser, amountOfRewardTokens + 1);
         rewardModule.transferFrom(sendingUser, receivingUser, amountOfRewardTokens);
 
-        assertEq(rewardModule.balanceOf(sendingUser), 0);
-        assertEq(rewardModule.balanceOf(receivingUser), amountOfRewardTokens);
+        assertEq(rewardModule.normalizedBalanceOf(sendingUser), 0);
+        assertEq(rewardModule.normalizedBalanceOf(receivingUser), amountOfRewardTokens);
         assertEq(rewardModule.allowance(sendingUser, spender), 0);
     }
 
@@ -318,8 +322,8 @@ contract RewardToken_UnitTest is RewardTokenSharedSetup {
         underlying.approve(address(rewardModule), INITIAL_UNDERYLING);
         rewardModule.mint(sendingUser, amountOfRewardTokens);
 
-        assertEq(rewardModule.balanceOf(sendingUser), amountOfRewardTokens);
-        assertEq(rewardModule.balanceOf(receivingUser), 0);
+        assertEq(rewardModule.normalizedBalanceOf(sendingUser), amountOfRewardTokens);
+        assertEq(rewardModule.normalizedBalanceOf(receivingUser), 0);
         assertEq(rewardModule.allowance(sendingUser, spender), 0);
         assertEq(underlying.balanceOf(address(this)), INITIAL_UNDERYLING - amountOfRewardTokens);
         assertEq(underlying.balanceOf(address(rewardModule)), amountOfRewardTokens);

--- a/test/unit/concrete/vault/Vault.t.sol
+++ b/test/unit/concrete/vault/Vault.t.sol
@@ -298,7 +298,7 @@ contract VaultSetUpTest is VaultSharedSetup {
 
         vault.deposit(depositAmount, address(this));
 
-        assertGt(weEthIonPool.balanceOf(address(vault)), 0, "deposited to weEthIonPool");
+        assertGt(weEthIonPool.normalizedBalanceOf(address(vault)), 0, "deposited to weEthIonPool");
 
         vm.prank(OWNER);
         vm.expectRevert(abi.encodeWithSelector(Vault.InvalidMarketRemovalNonZeroSupply.selector, weEthIonPool));
@@ -363,7 +363,7 @@ contract VaultSetUpTest is VaultSharedSetup {
         setERC20Balance(address(BASE_ASSET), address(this), depositAmount);
         vault.deposit(depositAmount, address(this));
 
-        assertGt(weEthIonPool.balanceOf(address(vault)), 0, "deposited to weEthIonPool");
+        assertGt(weEthIonPool.normalizedBalanceOf(address(vault)), 0, "deposited to weEthIonPool");
 
         bytes memory reallocateCalldata = abi.encodeWithSelector(Vault.reallocate.selector, allocs);
 
@@ -616,7 +616,7 @@ abstract contract VaultDeposit is VaultSharedSetup {
         updateSupplyCaps(vault, type(uint256).max, type(uint256).max, type(uint256).max);
         updateAllocationCaps(vault, type(uint256).max, type(uint256).max, type(uint256).max);
 
-        uint256 prevWeEthShares = weEthIonPool.balanceOf(address(vault));
+        uint256 prevWeEthShares = weEthIonPool.normalizedBalanceOf(address(vault));
 
         vault.deposit(depositAmount, address(this));
 
@@ -624,7 +624,7 @@ abstract contract VaultDeposit is VaultSharedSetup {
         assertEq(vault.balanceOf(address(this)), depositAmount, "user vault shares balance");
         assertEq(BASE_ASSET.balanceOf(address(vault)), 0, "base asset balance should be zero");
         assertEq(
-            weEthIonPool.getUnderlyingClaimOf(address(vault)),
+            weEthIonPool.balanceOf(address(vault)),
             claimAfterDeposit(prevWeEthShares, depositAmount, weEthIonPool.supplyFactor()),
             "vault iToken claim"
         );
@@ -638,9 +638,9 @@ abstract contract VaultDeposit is VaultSharedSetup {
         updateSupplyCaps(vault, type(uint256).max, type(uint256).max, type(uint256).max);
         updateAllocationCaps(vault, 1e18, 1e18, 1e18);
 
-        uint256 prevWeEthShares = weEthIonPool.balanceOf(address(vault));
-        uint256 prevRsEthShares = rsEthIonPool.balanceOf(address(vault));
-        uint256 prevRswEthShares = rswEthIonPool.balanceOf(address(vault));
+        uint256 prevWeEthShares = weEthIonPool.normalizedBalanceOf(address(vault));
+        uint256 prevRsEthShares = rsEthIonPool.normalizedBalanceOf(address(vault));
+        uint256 prevRswEthShares = rswEthIonPool.normalizedBalanceOf(address(vault));
 
         // 3e18 gets spread out equally amongst the three pools
         vault.deposit(depositAmount, address(this));
@@ -650,17 +650,17 @@ abstract contract VaultDeposit is VaultSharedSetup {
         assertEq(BASE_ASSET.balanceOf(address(vault)), 0, "base asset balance should be zero");
 
         assertEq(
-            weEthIonPool.getUnderlyingClaimOf(address(vault)),
+            weEthIonPool.balanceOf(address(vault)),
             claimAfterDeposit(prevWeEthShares, 1e18, weEthIonPool.supplyFactor()),
             "weEth vault iToken claim"
         );
         assertEq(
-            rsEthIonPool.getUnderlyingClaimOf(address(vault)),
+            rsEthIonPool.balanceOf(address(vault)),
             claimAfterDeposit(prevRsEthShares, 1e18, rsEthIonPool.supplyFactor()),
             "rsEth vault iToken claim"
         );
         assertEq(
-            rswEthIonPool.getUnderlyingClaimOf(address(vault)),
+            rswEthIonPool.balanceOf(address(vault)),
             claimAfterDeposit(prevRswEthShares, 1e18, rswEthIonPool.supplyFactor()),
             "rswEth vault iToken claim"
         );
@@ -674,9 +674,9 @@ abstract contract VaultDeposit is VaultSharedSetup {
         updateSupplyCaps(vault, type(uint256).max, type(uint256).max, type(uint256).max);
         updateAllocationCaps(vault, 3e18, 5e18, 7e18);
 
-        uint256 prevWeEthShares = weEthIonPool.balanceOf(address(vault));
-        uint256 prevRsEthShares = rsEthIonPool.balanceOf(address(vault));
-        uint256 prevRswEthShares = rswEthIonPool.balanceOf(address(vault));
+        uint256 prevWeEthShares = weEthIonPool.normalizedBalanceOf(address(vault));
+        uint256 prevRsEthShares = rsEthIonPool.normalizedBalanceOf(address(vault));
+        uint256 prevRswEthShares = rswEthIonPool.normalizedBalanceOf(address(vault));
 
         // 3e18 gets spread out equally amongst the three pools
         vault.deposit(depositAmount, address(this));
@@ -686,17 +686,17 @@ abstract contract VaultDeposit is VaultSharedSetup {
         assertEq(BASE_ASSET.balanceOf(address(vault)), 0, "base asset balance should be zero");
 
         assertEq(
-            weEthIonPool.getUnderlyingClaimOf(address(vault)),
+            weEthIonPool.balanceOf(address(vault)),
             claimAfterDeposit(prevWeEthShares, 2e18, weEthIonPool.supplyFactor()),
             "weEth vault iToken claim"
         );
         assertEq(
-            rsEthIonPool.getUnderlyingClaimOf(address(vault)),
+            rsEthIonPool.balanceOf(address(vault)),
             claimAfterDeposit(prevRsEthShares, 3e18, rsEthIonPool.supplyFactor()),
             "rsEth vault iToken claim"
         );
         assertEq(
-            rswEthIonPool.getUnderlyingClaimOf(address(vault)),
+            rswEthIonPool.balanceOf(address(vault)),
             claimAfterDeposit(prevRswEthShares, 5e18, rswEthIonPool.supplyFactor()),
             "rswEth vault iToken claim"
         );
@@ -712,9 +712,9 @@ abstract contract VaultDeposit is VaultSharedSetup {
         updateSupplyCaps(vault, 3e18, 10e18, 5e18);
         updateAllocationCaps(vault, 5e18, 7e18, 20e18);
 
-        uint256 prevWeEthShares = weEthIonPool.balanceOf(address(vault));
-        uint256 prevRsEthShares = rsEthIonPool.balanceOf(address(vault));
-        uint256 prevRswEthShares = rswEthIonPool.balanceOf(address(vault));
+        uint256 prevWeEthShares = weEthIonPool.normalizedBalanceOf(address(vault));
+        uint256 prevRsEthShares = rsEthIonPool.normalizedBalanceOf(address(vault));
+        uint256 prevRswEthShares = rswEthIonPool.normalizedBalanceOf(address(vault));
 
         vault.deposit(depositAmount, address(this));
 
@@ -723,17 +723,17 @@ abstract contract VaultDeposit is VaultSharedSetup {
         assertEq(BASE_ASSET.balanceOf(address(vault)), 0, "base asset balance should be zero");
 
         assertEq(
-            weEthIonPool.getUnderlyingClaimOf(address(vault)),
+            weEthIonPool.balanceOf(address(vault)),
             claimAfterDeposit(prevWeEthShares, 2e18, weEthIonPool.supplyFactor()),
             "weEth vault iToken claim"
         );
         assertEq(
-            rsEthIonPool.getUnderlyingClaimOf(address(vault)),
+            rsEthIonPool.balanceOf(address(vault)),
             claimAfterDeposit(prevRsEthShares, 3e18, rsEthIonPool.supplyFactor()),
             "rsEth vault iToken claim"
         );
         assertEq(
-            rswEthIonPool.getUnderlyingClaimOf(address(vault)),
+            rswEthIonPool.balanceOf(address(vault)),
             claimAfterDeposit(prevRswEthShares, 7e18, rswEthIonPool.supplyFactor()),
             "rswEth vault iToken claim"
         );
@@ -839,9 +839,7 @@ abstract contract VaultWithdraw is VaultSharedSetup {
         );
         assertEq(vault.totalSupply(), expectedNewTotalSupply, "vault shares total supply");
 
-        assertEq(
-            vault.totalAssets(), rsEthIonPool.getUnderlyingClaimOf(address(vault)), "single market for total assets"
-        );
+        assertEq(vault.totalAssets(), rsEthIonPool.balanceOf(address(vault)), "single market for total assets");
         assertEq(BASE_ASSET.balanceOf(address(vault)), 0, "valt's base asset balance should be zero");
 
         // user
@@ -900,10 +898,10 @@ abstract contract VaultWithdraw is VaultSharedSetup {
         );
         assertEq(vault.totalSupply(), expectedNewTotalSupply, "vault shares total supply");
 
-        assertEq(rsEthIonPool.getUnderlyingClaimOf(address(vault)), 0, "vault pool1 balance");
-        assertEq(rswEthIonPool.getUnderlyingClaimOf(address(vault)), 0, "vault pool2 balance");
+        assertEq(rsEthIonPool.balanceOf(address(vault)), 0, "vault pool1 balance");
+        assertEq(rswEthIonPool.balanceOf(address(vault)), 0, "vault pool2 balance");
         assertLe(
-            expectedNewTotalAssets - weEthIonPool.getUnderlyingClaimOf(address(vault)),
+            expectedNewTotalAssets - weEthIonPool.balanceOf(address(vault)),
             weEthIonPool.supplyFactor() / RAY,
             "vault pool3 balance"
         );
@@ -962,9 +960,9 @@ abstract contract VaultReallocate is VaultSharedSetup {
 
         uint256 prevTotalAssets = vault.totalAssets();
 
-        uint256 prevRsEthClaim = rsEthIonPool.getUnderlyingClaimOf(address(vault));
-        uint256 prevRswEthClaim = rswEthIonPool.getUnderlyingClaimOf(address(vault));
-        uint256 prevWeEthClaim = weEthIonPool.getUnderlyingClaimOf(address(vault));
+        uint256 prevRsEthClaim = rsEthIonPool.balanceOf(address(vault));
+        uint256 prevRswEthClaim = rswEthIonPool.balanceOf(address(vault));
+        uint256 prevWeEthClaim = weEthIonPool.balanceOf(address(vault));
 
         int256 rswEthDiff = -1e18;
         int256 weEthDiff = -2e18;
@@ -988,19 +986,19 @@ abstract contract VaultReallocate is VaultSharedSetup {
         uint256 newTotalAssets = vault.totalAssets();
 
         assertApproxEqAbs(
-            rsEthIonPool.getUnderlyingClaimOf(address(vault)),
+            rsEthIonPool.balanceOf(address(vault)),
             expNewRsEthClaim,
             rsEthIonPool.supplyFactor() / RAY,
             "rsEth vault iToken claim"
         );
         assertApproxEqAbs(
-            rswEthIonPool.getUnderlyingClaimOf(address(vault)),
+            rswEthIonPool.balanceOf(address(vault)),
             expNewRswEthClaim,
             rswEthIonPool.supplyFactor() / RAY,
             "rswEth vault iToken claim"
         );
         assertApproxEqAbs(
-            weEthIonPool.getUnderlyingClaimOf(address(vault)),
+            weEthIonPool.balanceOf(address(vault)),
             expNewWeEthClaim,
             weEthIonPool.supplyFactor() / RAY,
             "weEth vault iToken claim"
@@ -1028,9 +1026,9 @@ abstract contract VaultReallocate is VaultSharedSetup {
 
         updateAllocationCaps(vault, type(uint256).max, type(uint256).max, type(uint256).max);
 
-        uint256 prevWeEthClaim = weEthIonPool.getUnderlyingClaimOf(address(vault));
-        uint256 prevRswEthClaim = rswEthIonPool.getUnderlyingClaimOf(address(vault));
-        uint256 prevRsEthClaim = rsEthIonPool.getUnderlyingClaimOf(address(vault));
+        uint256 prevWeEthClaim = weEthIonPool.balanceOf(address(vault));
+        uint256 prevRswEthClaim = rswEthIonPool.balanceOf(address(vault));
+        uint256 prevRsEthClaim = rsEthIonPool.balanceOf(address(vault));
         uint256 expRswEthClaim = prevRswEthClaim + prevWeEthClaim + prevRsEthClaim;
 
         uint256 prevTotalAssets = vault.totalAssets();
@@ -1052,10 +1050,10 @@ abstract contract VaultReallocate is VaultSharedSetup {
 
         uint256 newTotalAssets = vault.totalAssets();
 
-        assertEq(rsEthIonPool.getUnderlyingClaimOf(address(vault)), 0, "rsEth vault iToken claim");
-        assertEq(weEthIonPool.getUnderlyingClaimOf(address(vault)), 0, "weEth vault iToken claim");
+        assertEq(rsEthIonPool.balanceOf(address(vault)), 0, "rsEth vault iToken claim");
+        assertEq(weEthIonPool.balanceOf(address(vault)), 0, "weEth vault iToken claim");
         assertApproxEqAbs(
-            rswEthIonPool.getUnderlyingClaimOf(address(vault)),
+            rswEthIonPool.balanceOf(address(vault)),
             expRswEthClaim,
             rswEthIonPool.supplyFactor() / RAY,
             "rswEth vault iToken claim"
@@ -1081,7 +1079,7 @@ abstract contract VaultReallocate is VaultSharedSetup {
 
         uint256 prevTotalAssets = vault.totalAssets();
 
-        uint256 weEthCurrentSupplied = weEthIonPool.getUnderlyingClaimOf(address(vault));
+        uint256 weEthCurrentSupplied = weEthIonPool.balanceOf(address(vault));
 
         // tries to deposit 2e18 + 2e18 to 3e18 allocation cap
         Vault.MarketAllocation[] memory allocs = new Vault.MarketAllocation[](3);
@@ -1173,20 +1171,14 @@ abstract contract VaultWithIdlePool is VaultSharedSetup {
         // rsEthIonPool should be full at 30e18
         // rswEthIonPool should be at 10e18
         assertLe(
-            10e18 - weEthIonPool.getUnderlyingClaimOf(address(vault)),
-            postDepositClaimRE(10e18, weEthIonPoolSF),
-            "weEthIonPool"
+            10e18 - weEthIonPool.balanceOf(address(vault)), postDepositClaimRE(10e18, weEthIonPoolSF), "weEthIonPool"
         );
         assertEq(BASE_ASSET.balanceOf(address(vault)), 20e18, "IDLE");
         assertLe(
-            30e18 - rsEthIonPool.getUnderlyingClaimOf(address(vault)),
-            postDepositClaimRE(30e18, rsEthIonPoolSF),
-            "rsEthIonPool"
+            30e18 - rsEthIonPool.balanceOf(address(vault)), postDepositClaimRE(30e18, rsEthIonPoolSF), "rsEthIonPool"
         );
         assertLe(
-            10e18 - rswEthIonPool.getUnderlyingClaimOf(address(vault)),
-            postDepositClaimRE(10e18, rswEthIonPoolSF),
-            "rswEthIonPool"
+            10e18 - rswEthIonPool.balanceOf(address(vault)), postDepositClaimRE(10e18, rswEthIonPoolSF), "rswEthIonPool"
         );
         assertEq(BASE_ASSET.balanceOf(address(this)), 0, "user balance");
     }
@@ -1221,18 +1213,18 @@ abstract contract VaultWithIdlePool is VaultSharedSetup {
 
         assertEq(remainingAssets, 0, "test variables");
         assertLe(
-            expectedWeEthIonPoolClaim - weEthIonPool.getUnderlyingClaimOf(address(vault)),
+            expectedWeEthIonPoolClaim - weEthIonPool.balanceOf(address(vault)),
             postDepositClaimRE(expectedWeEthIonPoolClaim, weEthIonPoolSF),
             "weEthIonPool"
         );
         assertEq(BASE_ASSET.balanceOf(address(vault)), expectedIdleClaim, "IDLE");
         assertLe(
-            expectedRsEthIonPoolClaim - rsEthIonPool.getUnderlyingClaimOf(address(vault)),
+            expectedRsEthIonPoolClaim - rsEthIonPool.balanceOf(address(vault)),
             postDepositClaimRE(expectedWeEthIonPoolClaim, rsEthIonPoolSF),
             "rsEthIonPool"
         );
         assertLe(
-            expectedRswEthIonPoolClaim - rswEthIonPool.getUnderlyingClaimOf(address(vault)),
+            expectedRswEthIonPoolClaim - rswEthIonPool.balanceOf(address(vault)),
             postDepositClaimRE(expectedRswEthIonPoolClaim, rswEthIonPoolSF),
             "rswEthIonPool"
         );
@@ -1250,10 +1242,10 @@ abstract contract VaultWithIdlePool is VaultSharedSetup {
         uint256 prevTotalAssets = vault.totalAssets();
         uint256 supplyFactor = rsEthIonPool.supplyFactor();
 
-        uint256 weEthIonPoolClaim = weEthIonPool.getUnderlyingClaimOf(address(vault));
+        uint256 weEthIonPoolClaim = weEthIonPool.balanceOf(address(vault));
         uint256 idleClaim = BASE_ASSET.balanceOf(address(vault));
-        uint256 rsEthIonPoolClaim = rsEthIonPool.getUnderlyingClaimOf(address(vault));
-        uint256 rswEthIonPoolClaim = rswEthIonPool.getUnderlyingClaimOf(address(vault));
+        uint256 rsEthIonPoolClaim = rsEthIonPool.balanceOf(address(vault));
+        uint256 rswEthIonPoolClaim = rswEthIonPool.balanceOf(address(vault));
 
         uint256 withdrawAmount = 40e18;
 
@@ -1283,14 +1275,14 @@ abstract contract VaultWithIdlePool is VaultSharedSetup {
             postDepositClaimRE(withdrawAmount, supplyFactor),
             "vault total assets"
         );
-        assertEq(weEthIonPool.getUnderlyingClaimOf(address(vault)), 0, "weEthIonPool claim");
+        assertEq(weEthIonPool.balanceOf(address(vault)), 0, "weEthIonPool claim");
         assertEq(BASE_ASSET.balanceOf(address(vault)), 0, "idle deposits");
         assertLt(
-            (rsEthIonPoolClaim - rsEthIonPoolWithdraw) - rsEthIonPool.getUnderlyingClaimOf(address(vault)),
+            (rsEthIonPoolClaim - rsEthIonPoolWithdraw) - rsEthIonPool.balanceOf(address(vault)),
             postDepositClaimRE(withdrawAmount, supplyFactor),
             "rsEthIonPool claim"
         );
-        assertEq(rswEthIonPool.getUnderlyingClaimOf(address(vault)), rswEthIonPoolClaim, "rswEthIonPool claim");
+        assertEq(rswEthIonPool.balanceOf(address(vault)), rswEthIonPoolClaim, "rswEthIonPool claim");
 
         // user gains withdrawn balance
         assertEq(BASE_ASSET.balanceOf(address(this)), withdrawAmount, "user base asset balance");
@@ -1349,10 +1341,10 @@ abstract contract VaultWithIdlePool is VaultSharedSetup {
         vault.updateAllocationCaps(ionPoolToUpdate, newAllocationCaps);
 
         // 10 weEth 20 idle 30 rsEth 10 rswEth
-        uint256 prevWeEthClaim = weEthIonPool.getUnderlyingClaimOf(address(vault));
+        uint256 prevWeEthClaim = weEthIonPool.balanceOf(address(vault));
         uint256 prevIdleClaim = BASE_ASSET.balanceOf(address(vault));
-        uint256 prevRsEthClaim = rsEthIonPool.getUnderlyingClaimOf(address(vault));
-        uint256 prevRswEthClaim = rswEthIonPool.getUnderlyingClaimOf(address(vault));
+        uint256 prevRsEthClaim = rsEthIonPool.balanceOf(address(vault));
+        uint256 prevRswEthClaim = rswEthIonPool.balanceOf(address(vault));
 
         uint256 weEthSF = weEthIonPool.supplyFactor();
         uint256 rsEthSF = rsEthIonPool.supplyFactor();
@@ -1375,17 +1367,13 @@ abstract contract VaultWithIdlePool is VaultSharedSetup {
         vault.reallocate(allocs);
 
         assertLt(
-            expectedWeEthClaim - weEthIonPool.getUnderlyingClaimOf(address(vault)),
-            postDepositClaimRE(0, weEthSF),
-            "weEthIonPol"
+            expectedWeEthClaim - weEthIonPool.balanceOf(address(vault)), postDepositClaimRE(0, weEthSF), "weEthIonPol"
         );
         assertEq(BASE_ASSET.balanceOf(address(vault)), expectedIdleClaim, "IDLE");
         assertLt(
-            expectedRsEthClaim - rsEthIonPool.getUnderlyingClaimOf(address(vault)),
-            postDepositClaimRE(0, rsEthSF),
-            "rswEthIonPol"
+            expectedRsEthClaim - rsEthIonPool.balanceOf(address(vault)), postDepositClaimRE(0, rsEthSF), "rswEthIonPol"
         );
-        assertEq(prevRswEthClaim, rswEthIonPool.getUnderlyingClaimOf(address(vault)), "rswEthIonPool");
+        assertEq(prevRswEthClaim, rswEthIonPool.balanceOf(address(vault)), "rswEthIonPool");
     }
 
     function test_Reallocate_WithdrawFromIdle() public {
@@ -1394,10 +1382,10 @@ abstract contract VaultWithIdlePool is VaultSharedSetup {
         vault.deposit(depositAmount, address(this));
 
         // 10 weEth 20 idle 30 rsEth 10 rswEth
-        uint256 prevWeEthClaim = weEthIonPool.getUnderlyingClaimOf(address(vault));
+        uint256 prevWeEthClaim = weEthIonPool.balanceOf(address(vault));
         uint256 prevIdleClaim = BASE_ASSET.balanceOf(address(vault));
-        uint256 prevRsEthClaim = rsEthIonPool.getUnderlyingClaimOf(address(vault));
-        uint256 prevRswEthClaim = rswEthIonPool.getUnderlyingClaimOf(address(vault));
+        uint256 prevRsEthClaim = rsEthIonPool.balanceOf(address(vault));
+        uint256 prevRswEthClaim = rswEthIonPool.balanceOf(address(vault));
 
         uint256 weEthSF = weEthIonPool.supplyFactor();
         uint256 rswEthSF = rswEthIonPool.supplyFactor();
@@ -1420,17 +1408,15 @@ abstract contract VaultWithIdlePool is VaultSharedSetup {
         vault.reallocate(allocs);
 
         assertLt(
-            expectedWeEthClaim - weEthIonPool.getUnderlyingClaimOf(address(vault)),
-            postDepositClaimRE(0, weEthSF),
-            "weEthIonPol"
+            expectedWeEthClaim - weEthIonPool.balanceOf(address(vault)), postDepositClaimRE(0, weEthSF), "weEthIonPol"
         );
         assertEq(BASE_ASSET.balanceOf(address(vault)), expectedIdleClaim, "IDLE");
         assertLt(
-            expectedRswEthClaim - rswEthIonPool.getUnderlyingClaimOf(address(vault)),
+            expectedRswEthClaim - rswEthIonPool.balanceOf(address(vault)),
             postDepositClaimRE(0, rswEthSF),
             "rswEthIonPol"
         );
-        assertEq(prevRsEthClaim, rsEthIonPool.getUnderlyingClaimOf(address(vault)), "rsEthIonPool");
+        assertEq(prevRsEthClaim, rsEthIonPool.balanceOf(address(vault)), "rsEthIonPool");
     }
 }
 

--- a/test/unit/fuzz/IonPool.t.sol
+++ b/test/unit/fuzz/IonPool.t.sol
@@ -71,11 +71,11 @@ abstract contract IonPool_LenderFuzzTestBase is IonPoolSharedSetup, IIonPoolEven
         ionPool.supply(lender1, supplyAmount, new bytes32[](0));
 
         assertEq(lens.liquidity(iIonPool), supplyAmountBeforeSupply + supplyAmount, "weth");
-        assertEq(ionPool.balanceOf(lender1), normalizedAmount, "ionPool balanceOf");
+        assertEq(ionPool.normalizedBalanceOf(lender1), normalizedAmount, "ionPool balanceOf");
 
         uint256 roundingError = currentSupplyFactor / RAY;
 
-        assertLe(ionPool.getUnderlyingClaimOf(lender1) - roundingError, supplyAmount, "balanceOf rounding error");
+        assertLe(ionPool.balanceOf(lender1) - roundingError, supplyAmount, "balanceOf rounding error");
     }
 
     function testFuzz_SupplyBaseToDifferentAddress(uint256 supplyAmount) public {
@@ -105,10 +105,10 @@ abstract contract IonPool_LenderFuzzTestBase is IonPoolSharedSetup, IIonPoolEven
         ionPool.supply(address(this), supplyAmount, new bytes32[](0));
 
         assertEq(lens.liquidity(iIonPool), supplyAmountBeforeSupply + supplyAmount);
-        assertEq(ionPool.balanceOf(address(this)), normalizedAmount);
+        assertEq(ionPool.normalizedBalanceOf(address(this)), normalizedAmount);
 
         uint256 roundingError = currentSupplyFactor / RAY;
-        assertLe(ionPool.getUnderlyingClaimOf(address(this)) - roundingError, supplyAmount);
+        assertLe(ionPool.balanceOf(address(this)) - roundingError, supplyAmount);
     }
 
     struct FuzzWithdrawBaseLocs {
@@ -132,7 +132,7 @@ abstract contract IonPool_LenderFuzzTestBase is IonPoolSharedSetup, IIonPoolEven
         // Changing supply factor, means that the interest will be deposited
         _changeSupplyFactorIfNeeded();
         uint256 supplyAmountAfterRebase = lens.liquidity(iIonPool);
-        uint256 lender1BalanceAfterRebase = ionPool.getUnderlyingClaimOf(lender1);
+        uint256 lender1BalanceAfterRebase = ionPool.balanceOf(lender1);
 
         assertEq(supplyAmountAfterRebase, lender1BalanceAfterRebase);
 
@@ -141,7 +141,7 @@ abstract contract IonPool_LenderFuzzTestBase is IonPoolSharedSetup, IIonPoolEven
         vm.assume(locs.withdrawAmount > 0);
 
         uint256 underlyingBeforeWithdraw = underlying.balanceOf(lender1);
-        uint256 rewardAssetBalanceBeforeWithdraw = ionPool.getUnderlyingClaimOf(lender1);
+        uint256 rewardAssetBalanceBeforeWithdraw = ionPool.balanceOf(lender1);
 
         locs.currentTotalDebt = lens.debt(iIonPool);
         (locs.supplyFactorIncrease,,, locs.newDebtIncrease,) = ionPool.calculateRewardAndDebtDistribution();
@@ -159,7 +159,7 @@ abstract contract IonPool_LenderFuzzTestBase is IonPoolSharedSetup, IIonPoolEven
         ionPool.withdraw(lender1, locs.withdrawAmount);
 
         uint256 underlyingAfterWithdraw = underlying.balanceOf(lender1);
-        uint256 rewardAssetBalanceAfterWithdraw = ionPool.getUnderlyingClaimOf(lender1);
+        uint256 rewardAssetBalanceAfterWithdraw = ionPool.balanceOf(lender1);
 
         uint256 underlyingWithdrawn = underlyingAfterWithdraw - underlyingBeforeWithdraw;
         uint256 rewardAssetBurned = rewardAssetBalanceBeforeWithdraw - rewardAssetBalanceAfterWithdraw;
@@ -170,7 +170,7 @@ abstract contract IonPool_LenderFuzzTestBase is IonPoolSharedSetup, IIonPoolEven
         assertGe(rewardAssetBurned, underlyingWithdrawn);
 
         uint256 roundingError = currentSupplyFactor / RAY;
-        assertLt(ionPool.balanceOf(lender1), lender1BalanceAfterRebase - locs.withdrawAmount + roundingError);
+        assertLt(ionPool.normalizedBalanceOf(lender1), lender1BalanceAfterRebase - locs.withdrawAmount + roundingError);
     }
 
     function testFuzz_WithdrawBaseToDifferentAddress(uint256 supplyAmount, uint256 withdrawAmount) public {
@@ -187,7 +187,7 @@ abstract contract IonPool_LenderFuzzTestBase is IonPoolSharedSetup, IIonPoolEven
         // Changing supply factor, means that the interest will be deposited
         _changeSupplyFactorIfNeeded();
         uint256 supplyAmountAfterRebase = lens.liquidity(iIonPool);
-        uint256 lender1BalanceAfterRebase = ionPool.getUnderlyingClaimOf(lender1);
+        uint256 lender1BalanceAfterRebase = ionPool.balanceOf(lender1);
 
         assertEq(supplyAmountAfterRebase, lender1BalanceAfterRebase, "amount after rebase");
 
@@ -196,7 +196,7 @@ abstract contract IonPool_LenderFuzzTestBase is IonPoolSharedSetup, IIonPoolEven
         vm.assume(locs.withdrawAmount > 0);
 
         uint256 underlyingBeforeWithdraw = underlying.balanceOf(lender2);
-        uint256 rewardAssetBalanceBeforeWithdraw = ionPool.getUnderlyingClaimOf(lender1);
+        uint256 rewardAssetBalanceBeforeWithdraw = ionPool.balanceOf(lender1);
 
         locs.currentTotalDebt = lens.debt(iIonPool);
         (locs.supplyFactorIncrease,,, locs.newDebtIncrease,) = ionPool.calculateRewardAndDebtDistribution();
@@ -214,7 +214,7 @@ abstract contract IonPool_LenderFuzzTestBase is IonPoolSharedSetup, IIonPoolEven
         ionPool.withdraw(lender2, locs.withdrawAmount);
 
         uint256 underlyingAfterWithdraw = underlying.balanceOf(lender2);
-        uint256 rewardAssetBalanceAfterWithdraw = ionPool.getUnderlyingClaimOf(lender1);
+        uint256 rewardAssetBalanceAfterWithdraw = ionPool.balanceOf(lender1);
 
         uint256 underlyingWithdrawn = underlyingAfterWithdraw - underlyingBeforeWithdraw;
         uint256 rewardAssetBurned = rewardAssetBalanceBeforeWithdraw - rewardAssetBalanceAfterWithdraw;
@@ -226,7 +226,7 @@ abstract contract IonPool_LenderFuzzTestBase is IonPoolSharedSetup, IIonPoolEven
 
         uint256 roundingError = currentSupplyFactor / RAY;
         assertLt(
-            ionPool.getUnderlyingClaimOf(lender1),
+            ionPool.balanceOf(lender1),
             lender1BalanceAfterRebase - locs.withdrawAmount + roundingError,
             "underlying claim"
         );
@@ -1268,7 +1268,7 @@ contract IonPool_BorrowerFuzzTest is IonPool_BorrowerFuzzTestBase {
 
         assertEq(lens.liquidity(iIonPool), INITIAL_LENDER_UNDERLYING_BALANCE);
         assertEq(underlying.balanceOf(address(ionPool)), INITIAL_LENDER_UNDERLYING_BALANCE);
-        assertEq(ionPool.balanceOf(lender2), INITIAL_LENDER_UNDERLYING_BALANCE);
+        assertEq(ionPool.normalizedBalanceOf(lender2), INITIAL_LENDER_UNDERLYING_BALANCE);
 
         for (uint256 i = 0; i < lens.ilkCount(iIonPool); i++) {
             assertEq(collaterals[i].allowance(borrower1, address(gemJoins[i])), type(uint256).max);

--- a/test/unit/fuzz/RewardToken.t.sol
+++ b/test/unit/fuzz/RewardToken.t.sol
@@ -29,7 +29,7 @@ contract RewardToken_FuzzUnitTest is RewardTokenSharedSetup {
         rewardModule.mint(address(0), amountOfRewards);
         rewardModule.mint(address(this), amountOfRewards);
 
-        assertEq(rewardModule.balanceOf(address(this)), amountOfRewards);
+        assertEq(rewardModule.normalizedBalanceOf(address(this)), amountOfRewards);
         assertEq(underlying.balanceOf(address(this)), 0);
         assertEq(underlying.balanceOf(address(rewardModule)), amountOfRewards);
     }
@@ -45,14 +45,14 @@ contract RewardToken_FuzzUnitTest is RewardTokenSharedSetup {
         underlying.approve(address(rewardModule), amountOfRewards);
         rewardModule.mint(address(this), amountOfRewards);
 
-        assertEq(rewardModule.balanceOf(address(this)), amountOfRewards);
+        assertEq(rewardModule.normalizedBalanceOf(address(this)), amountOfRewards);
         assertEq(underlying.balanceOf(address(this)), 0);
 
         vm.expectRevert(abi.encodeWithSelector(RewardToken.InvalidSender.selector, address(0)));
         rewardModule.burn(address(0), address(this), amountOfRewards);
         rewardModule.burn(address(this), address(this), amountOfRewards);
 
-        assertEq(rewardModule.balanceOf(address(this)), 0);
+        assertEq(rewardModule.normalizedBalanceOf(address(this)), 0);
     }
 
     function testFuzz_MintRewardWithSupplyFactorChange(uint256 amountOfRewards, uint256 supplyFactorNew) external {
@@ -71,8 +71,8 @@ contract RewardToken_FuzzUnitTest is RewardTokenSharedSetup {
 
         uint256 expectedNormalizedMint1 = amountOfRewards.rayDivDown(supplyFactorOld);
 
-        assertEq(rewardModule.balanceOf(address(this)), expectedNormalizedMint1);
-        assertEq(rewardModule.getUnderlyingClaimOf(address(this)), amountOfRewards);
+        assertEq(rewardModule.normalizedBalanceOf(address(this)), expectedNormalizedMint1);
+        assertEq(rewardModule.balanceOf(address(this)), amountOfRewards);
         assertEq(underlying.balanceOf(address(this)), 0);
         assertEq(underlying.balanceOf(address(rewardModule)), amountOfRewards);
 
@@ -90,8 +90,8 @@ contract RewardToken_FuzzUnitTest is RewardTokenSharedSetup {
         uint256 totalDepositsNormalized = expectedNormalizedMint1 + expectedNormalizedMint2;
         uint256 totalValue = totalDepositsNormalized.rayMulDown(supplyFactorNew);
 
-        assertEq(rewardModule.balanceOf(address(this)), totalDepositsNormalized);
-        assertEq(rewardModule.getUnderlyingClaimOf(address(this)), totalValue);
+        assertEq(rewardModule.normalizedBalanceOf(address(this)), totalDepositsNormalized);
+        assertEq(rewardModule.balanceOf(address(this)), totalValue);
         assertEq(underlying.balanceOf(address(this)), 0);
         assertEq(underlying.balanceOf(address(rewardModule)), totalDeposited + interestCreated);
     }
@@ -112,8 +112,8 @@ contract RewardToken_FuzzUnitTest is RewardTokenSharedSetup {
 
         uint256 expectedNormalizedMint1 = amountOfRewards.rayDivDown(supplyFactorOld);
 
-        assertEq(rewardModule.balanceOf(address(this)), expectedNormalizedMint1);
-        assertEq(rewardModule.getUnderlyingClaimOf(address(this)), amountOfRewards);
+        assertEq(rewardModule.normalizedBalanceOf(address(this)), expectedNormalizedMint1);
+        assertEq(rewardModule.balanceOf(address(this)), amountOfRewards);
         assertEq(underlying.balanceOf(address(this)), 0);
         assertEq(underlying.balanceOf(address(rewardModule)), amountOfRewards);
 
@@ -131,8 +131,8 @@ contract RewardToken_FuzzUnitTest is RewardTokenSharedSetup {
         uint256 totalDepositsNormalized = expectedNormalizedMint1 + expectedNormalizedMint2;
         uint256 totalValue = totalDepositsNormalized.rayMulDown(supplyFactorNew);
 
-        assertEq(rewardModule.balanceOf(address(this)), totalDepositsNormalized);
-        assertEq(rewardModule.getUnderlyingClaimOf(address(this)), totalValue);
+        assertEq(rewardModule.normalizedBalanceOf(address(this)), totalDepositsNormalized);
+        assertEq(rewardModule.balanceOf(address(this)), totalValue);
         assertEq(underlying.balanceOf(address(this)), 0);
         assertEq(underlying.balanceOf(address(rewardModule)), totalDeposited + interestCreated);
 
@@ -153,7 +153,7 @@ contract RewardToken_FuzzUnitTest is RewardTokenSharedSetup {
         underlying.approve(address(rewardModule), amountOfRewardTokens);
         rewardModule.mint(address(this), amountOfRewardTokens);
 
-        assertEq(rewardModule.balanceOf(address(this)), amountOfRewardTokens);
+        assertEq(rewardModule.normalizedBalanceOf(address(this)), amountOfRewardTokens);
         assertEq(underlying.balanceOf(address(this)), 0);
         assertEq(underlying.balanceOf(address(rewardModule)), amountOfRewardTokens);
 
@@ -172,8 +172,8 @@ contract RewardToken_FuzzUnitTest is RewardTokenSharedSetup {
         rewardModule.transfer(address(this), amountOfRewardTokens);
         rewardModule.transfer(receivingUser, amountOfRewardTokens);
 
-        assertEq(rewardModule.balanceOf(address(this)), 0);
-        assertEq(rewardModule.balanceOf(receivingUser), amountOfRewardTokens);
+        assertEq(rewardModule.normalizedBalanceOf(address(this)), 0);
+        assertEq(rewardModule.normalizedBalanceOf(receivingUser), amountOfRewardTokens);
         assertEq(underlying.balanceOf(address(this)), 0);
     }
 
@@ -186,8 +186,8 @@ contract RewardToken_FuzzUnitTest is RewardTokenSharedSetup {
         underlying.approve(address(rewardModule), amountOfRewardTokens);
         rewardModule.mint(sendingUser, amountOfRewardTokens);
 
-        assertEq(rewardModule.balanceOf(sendingUser), amountOfRewardTokens);
-        assertEq(rewardModule.balanceOf(receivingUser), 0);
+        assertEq(rewardModule.normalizedBalanceOf(sendingUser), amountOfRewardTokens);
+        assertEq(rewardModule.normalizedBalanceOf(receivingUser), 0);
         assertEq(rewardModule.allowance(sendingUser, spender), 0);
         assertEq(underlying.balanceOf(address(this)), 0);
         assertEq(underlying.balanceOf(address(rewardModule)), amountOfRewardTokens);
@@ -215,8 +215,8 @@ contract RewardToken_FuzzUnitTest is RewardTokenSharedSetup {
         rewardModule.transferFrom(sendingUser, receivingUser, amountOfRewardTokens + 1);
         rewardModule.transferFrom(sendingUser, receivingUser, amountOfRewardTokens);
 
-        assertEq(rewardModule.balanceOf(sendingUser), 0);
-        assertEq(rewardModule.balanceOf(receivingUser), amountOfRewardTokens);
+        assertEq(rewardModule.normalizedBalanceOf(sendingUser), 0);
+        assertEq(rewardModule.normalizedBalanceOf(receivingUser), amountOfRewardTokens);
         assertEq(rewardModule.allowance(sendingUser, spender), 0);
     }
 
@@ -229,8 +229,8 @@ contract RewardToken_FuzzUnitTest is RewardTokenSharedSetup {
         underlying.approve(address(rewardModule), amountOfRewardTokens);
         rewardModule.mint(sendingUser, amountOfRewardTokens);
 
-        assertEq(rewardModule.balanceOf(sendingUser), amountOfRewardTokens);
-        assertEq(rewardModule.balanceOf(receivingUser), 0);
+        assertEq(rewardModule.normalizedBalanceOf(sendingUser), amountOfRewardTokens);
+        assertEq(rewardModule.normalizedBalanceOf(receivingUser), 0);
         assertEq(rewardModule.allowance(sendingUser, spender), 0);
         assertEq(underlying.balanceOf(address(this)), 0);
         assertEq(underlying.balanceOf(address(rewardModule)), amountOfRewardTokens);
@@ -278,8 +278,8 @@ contract RewardToken_FuzzUnitTest is RewardTokenSharedSetup {
         rewardModule.transferFrom(sendingUser, receivingUser, amountOfRewardTokens + 1);
         rewardModule.transferFrom(sendingUser, receivingUser, amountOfRewardTokens);
 
-        assertEq(rewardModule.balanceOf(sendingUser), 0);
-        assertEq(rewardModule.balanceOf(receivingUser), amountOfRewardTokens);
+        assertEq(rewardModule.normalizedBalanceOf(sendingUser), 0);
+        assertEq(rewardModule.normalizedBalanceOf(receivingUser), amountOfRewardTokens);
         assertEq(rewardModule.allowance(sendingUser, spender), 0);
     }
 
@@ -306,8 +306,8 @@ contract RewardToken_FuzzUnitTest is RewardTokenSharedSetup {
 
         underlying.approve(address(rewardModule), locals.amountOfRewardTokens);
         rewardModule.mint(sendingUser, locals.amountOfRewardTokens);
-        assertEq(rewardModule.balanceOf(sendingUser), locals.amountOfRewardTokens);
-        assertEq(rewardModule.balanceOf(receivingUser), 0);
+        assertEq(rewardModule.normalizedBalanceOf(sendingUser), locals.amountOfRewardTokens);
+        assertEq(rewardModule.normalizedBalanceOf(receivingUser), 0);
         assertEq(rewardModule.allowance(sendingUser, spender), 0);
         assertEq(underlying.balanceOf(address(this)), 0);
         assertEq(underlying.balanceOf(address(rewardModule)), locals.amountOfRewardTokens);

--- a/test/unit/fuzz/vault/Vault.t.sol
+++ b/test/unit/fuzz/vault/Vault.t.sol
@@ -37,7 +37,7 @@ contract Vault_Fuzz is VaultSharedSetup {
         weEthIonPool.supply(address(this), assets, new bytes32[](0));
 
         uint256 expectedClaim = assets;
-        uint256 resultingClaim = weEthIonPool.getUnderlyingClaimOf(address(this));
+        uint256 resultingClaim = weEthIonPool.balanceOf(address(this));
 
         uint256 re = assets - ((assets * RAY - ((assets * RAY) % supplyFactor)) / RAY);
         assertLe(expectedClaim - resultingClaim, (supplyFactor - 2) / RAY + 1);


### PR DESCRIPTION
- Reverts the changes in `RewardToken` that were associated with the rebasing to non-rebasing transition. 
- Only changes should be the function names in `RewardToken.sol` and the function names used by `IonPool` and `Vault` contracts. 