### PR TITLE
M-05 Fix [PAG]

### DIFF
--- a/test/helpers/VaultSharedSetup.sol
+++ b/test/helpers/VaultSharedSetup.sol
@@ -284,4 +284,10 @@ contract VaultSharedSetup is IonPoolSharedSetup {
         IonPoolExposed(address(rsEthIonPool)).setSupplyFactor(7.1336673e27);
         IonPoolExposed(address(rswEthIonPool)).setSupplyFactor(10.1336673e27);
     }
+
+    function _zeroFloorSub(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        assembly {
+            z := mul(gt(x, y), sub(x, y))
+        }
+    }
 }


### PR DESCRIPTION
- [x] The rounding direction issue in M-05 is invalid. But more tests are added. 
- [x] Implement try/catch to skip supply/withdraw from a reverting `IonPool`. The `IonPool` supply or withdraw can revert in cases of a pause or trying to mint or burn zero amounts.