### PR TITLE
L-03 Fix [PAG]

### DIFF
--- a/src/token/RewardToken.sol
+++ b/src/token/RewardToken.sol
@@ -519,9 +519,9 @@ abstract contract RewardToken is
             return 0;
         }
 
-        (uint256 totalSupplyFactorIncrease,,,,) = calculateRewardAndDebtDistribution();
+        (uint256 totalSupplyFactorIncrease, uint256 totalTreasuryMintAmount,,,) = calculateRewardAndDebtDistribution();
 
-        return _normalizedTotalSupply.rayMulDown($.supplyFactor + totalSupplyFactorIncrease);
+        return _normalizedTotalSupply.rayMulDown($.supplyFactor + totalSupplyFactorIncrease) + totalTreasuryMintAmount;
     }
 
     function normalizedTotalSupplyUnaccrued() public view returns (uint256) {


### PR DESCRIPTION
- PR's into #95 
- Because this is after the revert to rebasing model, the `getTotalUnderlyingClaims` was renamed to `totalSupply`. So the `totalSupply` function was fixed to include the treasury mint amount.