### PR TITLE
M-03 Fix [PAG]

### DIFF
--- a/src/vault/Vault.sol
+++ b/src/vault/Vault.sol
@@ -86,6 +86,13 @@ contract Vault is ERC4626, Multicall, AccessControlDefaultAdminRules, Reentrancy
         int256 assets;
     }
 
+    struct MarketsArgs {
+        IIonPool[] marketsToAdd;
+        uint256[] allocationCaps;
+        IIonPool[] newSupplyQueue;
+        IIonPool[] newWithdrawQueue;
+    }
+
     constructor(
         IERC20 _baseAsset,
         address _feeRecipient,
@@ -93,7 +100,8 @@ contract Vault is ERC4626, Multicall, AccessControlDefaultAdminRules, Reentrancy
         string memory _name,
         string memory _symbol,
         uint48 initialDelay,
-        address initialDefaultAdmin
+        address initialDefaultAdmin,
+        MarketsArgs memory marketsArgs
     )
         ERC4626(_baseAsset)
         ERC20(_name, _symbol)
@@ -105,6 +113,13 @@ contract Vault is ERC4626, Multicall, AccessControlDefaultAdminRules, Reentrancy
         feeRecipient = _feeRecipient;
 
         DECIMALS_OFFSET = uint8(_zeroFloorSub(uint256(18), IERC20Metadata(address(_baseAsset)).decimals()));
+
+        _addSupportedMarkets(
+            marketsArgs.marketsToAdd,
+            marketsArgs.allocationCaps,
+            marketsArgs.newSupplyQueue,
+            marketsArgs.newWithdrawQueue
+        );
     }
 
     /**
@@ -138,13 +153,24 @@ contract Vault is ERC4626, Multicall, AccessControlDefaultAdminRules, Reentrancy
      * @param newWithdrawQueue Desired withdraw queue of IonPools for all resulting supported markets.
      */
     function addSupportedMarkets(
-        IIonPool[] calldata marketsToAdd,
-        uint256[] calldata allocationCaps,
-        IIonPool[] calldata newSupplyQueue,
-        IIonPool[] calldata newWithdrawQueue
+        IIonPool[] memory marketsToAdd,
+        uint256[] memory allocationCaps,
+        IIonPool[] memory newSupplyQueue,
+        IIonPool[] memory newWithdrawQueue
     )
-        public
+        external
         onlyRole(OWNER_ROLE)
+    {
+        _addSupportedMarkets(marketsToAdd, allocationCaps, newSupplyQueue, newWithdrawQueue);
+    }
+
+    function _addSupportedMarkets(
+        IIonPool[] memory marketsToAdd,
+        uint256[] memory allocationCaps,
+        IIonPool[] memory newSupplyQueue,
+        IIonPool[] memory newWithdrawQueue
+    )
+        internal
     {
         if (marketsToAdd.length != allocationCaps.length) revert MarketsAndAllocationCapLengthMustBeEqual();
 
@@ -167,8 +193,8 @@ contract Vault is ERC4626, Multicall, AccessControlDefaultAdminRules, Reentrancy
             }
         }
 
-        updateSupplyQueue(newSupplyQueue);
-        updateWithdrawQueue(newWithdrawQueue);
+        _updateSupplyQueue(newSupplyQueue);
+        _updateWithdrawQueue(newWithdrawQueue);
     }
 
     /**
@@ -211,8 +237,8 @@ contract Vault is ERC4626, Multicall, AccessControlDefaultAdminRules, Reentrancy
                 ++i;
             }
         }
-        updateSupplyQueue(newSupplyQueue);
-        updateWithdrawQueue(newWithdrawQueue);
+        _updateSupplyQueue(newSupplyQueue);
+        _updateWithdrawQueue(newWithdrawQueue);
     }
 
     /**
@@ -220,7 +246,11 @@ contract Vault is ERC4626, Multicall, AccessControlDefaultAdminRules, Reentrancy
      * @dev Each IonPool in the queue must be part of the `supportedMarkets` set.
      * @param newSupplyQueue The new supply queue ordering.
      */
-    function updateSupplyQueue(IIonPool[] calldata newSupplyQueue) public onlyRole(ALLOCATOR_ROLE) {
+    function updateSupplyQueue(IIonPool[] memory newSupplyQueue) external onlyRole(ALLOCATOR_ROLE) {
+        _updateSupplyQueue(newSupplyQueue);
+    }
+
+    function _updateSupplyQueue(IIonPool[] memory newSupplyQueue) internal {
         _validateQueueInput(newSupplyQueue);
 
         supplyQueue = newSupplyQueue;
@@ -233,7 +263,11 @@ contract Vault is ERC4626, Multicall, AccessControlDefaultAdminRules, Reentrancy
      * @dev The IonPool in the queue must be part of the `supportedMarkets` set.
      * @param newWithdrawQueue The new withdraw queue ordering.
      */
-    function updateWithdrawQueue(IIonPool[] calldata newWithdrawQueue) public onlyRole(ALLOCATOR_ROLE) {
+    function updateWithdrawQueue(IIonPool[] memory newWithdrawQueue) external onlyRole(ALLOCATOR_ROLE) {
+        _updateWithdrawQueue(newWithdrawQueue);
+    }
+
+    function _updateWithdrawQueue(IIonPool[] memory newWithdrawQueue) internal {
         _validateQueueInput(newWithdrawQueue);
 
         withdrawQueue = newWithdrawQueue;
@@ -249,7 +283,7 @@ contract Vault is ERC4626, Multicall, AccessControlDefaultAdminRules, Reentrancy
      * The above rule enforces that the queue must have all and only the elements in the `supportedMarkets` set.
      * @param queue The queue being validated.
      */
-    function _validateQueueInput(IIonPool[] calldata queue) internal view {
+    function _validateQueueInput(IIonPool[] memory queue) internal view {
         uint256 _supportedMarketsLength = supportedMarkets.length();
         uint256 queueLength = queue.length;
 
@@ -705,9 +739,7 @@ contract Vault is ERC4626, Multicall, AccessControlDefaultAdminRules, Reentrancy
 
     function _deposit(address caller, address receiver, uint256 assets, uint256 shares) internal override {
         super._deposit(caller, receiver, assets, shares);
-
         _supplyToIonPool(assets);
-
         _updateLastTotalAssets(lastTotalAssets + assets);
     }
 

--- a/src/vault/VaultFactory.sol
+++ b/src/vault/VaultFactory.sol
@@ -64,7 +64,11 @@ contract VaultFactory {
 
         baseAsset.safeTransferFrom(msg.sender, address(this), initialDeposit);
         baseAsset.approve(address(vault), initialDeposit);
-        vault.deposit(initialDeposit, msg.sender);
+        uint256 sharesMinted = vault.deposit(initialDeposit, address(this));
+
+        // The factory keeps 1e3 shares to reduce inflation attack vector.
+        // Effectively burns this amount of shares by locking it in the factory.
+        vault.transfer(msg.sender, sharesMinted - 1e3);
 
         emit CreateVault(address(vault), baseAsset, feeRecipient, feePercentage, name, symbol, initialDefaultAdmin);
     }

--- a/src/vault/VaultFactory.sol
+++ b/src/vault/VaultFactory.sol
@@ -28,10 +28,13 @@ contract VaultFactory {
     // --- External ---
 
     /**
-     * @notice Deploys a new Ion Lending Vault. Transfers 1 gwei of base asset
-     * from the caller to initiate an initial deposit to the vault.
-     * @dev The 1e9 initial deposit amount was chosen to defend against
-     * inflation attacks.
+     * @notice Deploys a new Ion Lending Vault. Transfers the `initialDeposit`
+     * amount of the base asset from the caller initiate the first deposit to
+     * the vault. The minimum `initialDeposit` is 1e3. If less, this call would
+     * underflow as it will always burn 1e3 shares of the total shares minted to
+     * defend against inflation attacks.
+     * @dev The 1e3 initial deposit amount was chosen to defend against
+     * inflation attacks, referencing the UniV2 LP token implementation.
      * @param baseAsset The asset that is being lent out to IonPools.
      * @param feeRecipient Address that receives the accrued manager fees.
      * @param feePercentage Fee percentage to be set.

--- a/src/vault/VaultFactory.sol
+++ b/src/vault/VaultFactory.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.21;
 
 import { Vault } from "./Vault.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+import { SafeERC20 } from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /**
  * @title Ion Lending Vault Factory
@@ -10,6 +11,8 @@ import { IERC20 } from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
  * @notice Factory contract for deploying Ion Lending Vaults.
  */
 contract VaultFactory {
+    using SafeERC20 for IERC20;
+
     // --- Events ---
 
     event CreateVault(
@@ -25,7 +28,10 @@ contract VaultFactory {
     // --- External ---
 
     /**
-     * @notice Deploys a new Ion Lending Vault.
+     * @notice Deploys a new Ion Lending Vault. Transfers 1 gwei of base asset
+     * from the caller to initiate an initial deposit to the vault.
+     * @dev The 1e9 initial deposit amount was chosen to defend against
+     * inflation attacks.
      * @param baseAsset The asset that is being lent out to IonPools.
      * @param feeRecipient Address that receives the accrued manager fees.
      * @param feePercentage Fee percentage to be set.
@@ -34,6 +40,8 @@ contract VaultFactory {
      * @param initialDelay The initial delay for default admin transfers.
      * @param initialDefaultAdmin The initial default admin for the vault.
      * @param salt The salt used for CREATE2 deployment.
+     * @param marketsArgs Arguments for the markets to be added to the vault.
+     * @param initialDeposit The initial deposit to be made to the vault.
      */
     function createVault(
         IERC20 baseAsset,
@@ -43,15 +51,20 @@ contract VaultFactory {
         string memory symbol,
         uint48 initialDelay,
         address initialDefaultAdmin,
-        bytes32 salt
+        bytes32 salt,
+        Vault.MarketsArgs memory marketsArgs,
+        uint256 initialDeposit
     )
         external
         returns (Vault vault)
     {
-        // TODO use named args syntax
         vault = new Vault{ salt: salt }(
-            baseAsset, feeRecipient, feePercentage, name, symbol, initialDelay, initialDefaultAdmin
+            baseAsset, feeRecipient, feePercentage, name, symbol, initialDelay, initialDefaultAdmin, marketsArgs
         );
+
+        baseAsset.safeTransferFrom(msg.sender, address(this), initialDeposit);
+        baseAsset.approve(address(vault), initialDeposit);
+        vault.deposit(initialDeposit, msg.sender);
 
         emit CreateVault(address(vault), baseAsset, feeRecipient, feePercentage, name, symbol, initialDefaultAdmin);
     }

--- a/test/fork/concrete/vault/VaultFactory.t.sol
+++ b/test/fork/concrete/vault/VaultFactory.t.sol
@@ -6,6 +6,7 @@ import { VaultFactory } from "./../../../../src/vault/VaultFactory.sol";
 import { VaultSharedSetup } from "../../../helpers/VaultSharedSetup.sol";
 import { ERC20PresetMinterPauser } from "../../../helpers/ERC20PresetMinterPauser.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import { IIonPool } from "./../../../../src/interfaces/IIonPool.sol";
 
 contract VaultFactoryTest is VaultSharedSetup {
     VaultFactory factory;
@@ -16,30 +17,116 @@ contract VaultFactoryTest is VaultSharedSetup {
     string internal name = "Vault Token";
     string internal symbol = "VT";
 
+    IIonPool[] internal marketsToAdd;
+    uint256[] internal allocationCaps;
+    IIonPool[] internal newSupplyQueue;
+    IIonPool[] internal newWithdrawQueue;
+
     function setUp() public override {
         super.setUp();
 
         factory = new VaultFactory();
+
+        marketsToAdd.push(weEthIonPool);
+        marketsToAdd.push(rsEthIonPool);
+        marketsToAdd.push(rswEthIonPool);
+
+        allocationCaps.push(1e18);
+        allocationCaps.push(2e18);
+        allocationCaps.push(3e18);
+
+        newSupplyQueue.push(weEthIonPool);
+        newSupplyQueue.push(rswEthIonPool);
+        newSupplyQueue.push(rsEthIonPool);
+
+        newWithdrawQueue.push(rswEthIonPool);
+        newWithdrawQueue.push(rsEthIonPool);
+        newWithdrawQueue.push(weEthIonPool);
+
+        marketsArgs.marketsToAdd = marketsToAdd;
+        marketsArgs.allocationCaps = allocationCaps;
+        marketsArgs.newSupplyQueue = newSupplyQueue;
+        marketsArgs.newWithdrawQueue = newWithdrawQueue;
+
+        setERC20Balance(address(BASE_ASSET), address(this), MIN_INITIAL_DEPOSIT);
+        BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
     }
 
     function test_CreateVault() public {
         bytes32 salt = keccak256("random salt");
-        Vault vault =
-            factory.createVault(baseAsset, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, salt);
+        Vault vault = factory.createVault(
+            baseAsset,
+            feeRecipient,
+            feePercentage,
+            name,
+            symbol,
+            INITIAL_DELAY,
+            VAULT_ADMIN,
+            salt,
+            marketsArgs,
+            MIN_INITIAL_DEPOSIT
+        );
 
-        assertEq(VAULT_ADMIN, vault.defaultAdmin(), "default admin");
-        assertEq(feeRecipient, vault.feeRecipient(), "fee recipient");
-        assertEq(address(baseAsset), address(vault.BASE_ASSET()), "base asset");
+        address[] memory supportedMarkets = vault.getSupportedMarkets();
+
+        IIonPool firstInSupplyQueue = vault.supplyQueue(0);
+        IIonPool secondInSupplyQueue = vault.supplyQueue(1);
+        IIonPool thirdInSupplyQueue = vault.supplyQueue(2);
+
+        IIonPool firstInWithdrawQueue = vault.withdrawQueue(0);
+        IIonPool secondInWithdrawQueue = vault.withdrawQueue(1);
+        IIonPool thirdInWithdrawQueue = vault.withdrawQueue(2);
+
+        assertEq(vault.defaultAdmin(), VAULT_ADMIN, "default admin");
+        assertEq(vault.feeRecipient(), feeRecipient, "fee recipient");
+        assertEq(vault.feePercentage(), feePercentage, "fee percentage");
+        assertEq(address(vault.BASE_ASSET()), address(baseAsset), "base asset");
+
+        assertEq(supportedMarkets.length, 3, "supported markets length");
+
+        for (uint256 i = 0; i != supportedMarkets.length; ++i) {
+            assertEq(address(supportedMarkets[i]), address(marketsToAdd[i]), "supported markets");
+            assertEq(address(vault.supplyQueue(i)), address(newSupplyQueue[i]), "supply queue");
+            assertEq(address(vault.withdrawQueue(i)), address(newWithdrawQueue[i]), "withdraw queue");
+        }
+
+        // initial deposits
+        assertEq(BASE_ASSET.balanceOf(address(this)), 0, "initial deposit spent");
+        assertEq(vault.totalAssets(), MIN_INITIAL_DEPOSIT, "total assets");
+        assertEq(vault.totalSupply(), MIN_INITIAL_DEPOSIT, "total supply");
     }
 
     function test_CreateVault_Twice() public {
         bytes32 salt = keccak256("first random salt");
-        Vault vault =
-            factory.createVault(baseAsset, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, salt);
+        Vault vault = factory.createVault(
+            baseAsset,
+            feeRecipient,
+            feePercentage,
+            name,
+            symbol,
+            INITIAL_DELAY,
+            VAULT_ADMIN,
+            salt,
+            marketsArgs,
+            MIN_INITIAL_DEPOSIT
+        );
+
+        setERC20Balance(address(BASE_ASSET), address(this), MIN_INITIAL_DEPOSIT);
+        BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
 
         bytes32 salt2 = keccak256("second random salt");
-        Vault vault2 =
-            factory.createVault(baseAsset, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, salt2);
+        Vault vault2 = factory.createVault(
+            baseAsset,
+            feeRecipient,
+            feePercentage,
+            name,
+            symbol,
+            INITIAL_DELAY,
+            VAULT_ADMIN,
+            salt2,
+            marketsArgs,
+            MIN_INITIAL_DEPOSIT
+        );
 
         assertEq(VAULT_ADMIN, vault.defaultAdmin(), "default admin");
         assertEq(feeRecipient, vault.feeRecipient(), "fee recipient");
@@ -52,24 +139,77 @@ contract VaultFactoryTest is VaultSharedSetup {
 
     function test_Revert_CreateVault_SameSaltTwice() public {
         bytes32 salt = keccak256("random salt");
-        Vault vault =
-            factory.createVault(baseAsset, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, salt);
+        Vault vault = factory.createVault(
+            baseAsset,
+            feeRecipient,
+            feePercentage,
+            name,
+            symbol,
+            INITIAL_DELAY,
+            VAULT_ADMIN,
+            salt,
+            marketsArgs,
+            MIN_INITIAL_DEPOSIT
+        );
 
         vm.expectRevert();
-        Vault vault2 =
-            factory.createVault(baseAsset, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, salt);
+        Vault vault2 = factory.createVault(
+            baseAsset,
+            feeRecipient,
+            feePercentage,
+            name,
+            symbol,
+            INITIAL_DELAY,
+            VAULT_ADMIN,
+            salt,
+            marketsArgs,
+            MIN_INITIAL_DEPOSIT
+        );
     }
 
     function test_CreateVault_SameSaltDifferentBytecode() public {
         bytes32 salt = keccak256("random salt");
 
-        Vault vault =
-            factory.createVault(BASE_ASSET, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, salt);
+        Vault vault = factory.createVault(
+            BASE_ASSET,
+            feeRecipient,
+            feePercentage,
+            name,
+            symbol,
+            INITIAL_DELAY,
+            VAULT_ADMIN,
+            salt,
+            marketsArgs,
+            MIN_INITIAL_DEPOSIT
+        );
 
+        // Deploy a vault with different base assets
         IERC20 diffBaseAsset = IERC20(address(new ERC20PresetMinterPauser("Another Wrapped Staked ETH", "wstETH2")));
 
+        IIonPool[] memory markets = new IIonPool[](3);
+        markets[0] = deployIonPool(diffBaseAsset, WEETH, address(this));
+        markets[1] = deployIonPool(diffBaseAsset, RSETH, address(this));
+        markets[2] = deployIonPool(diffBaseAsset, RSWETH, address(this));
+
+        marketsArgs.marketsToAdd = markets;
+        marketsArgs.allocationCaps = allocationCaps;
+        marketsArgs.newSupplyQueue = markets;
+        marketsArgs.newWithdrawQueue = markets;
+
+        setERC20Balance(address(diffBaseAsset), address(this), MIN_INITIAL_DEPOSIT);
+        diffBaseAsset.approve(address(factory), MIN_INITIAL_DEPOSIT);
+
         Vault vault2 = factory.createVault(
-            diffBaseAsset, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, salt
+            diffBaseAsset,
+            feeRecipient,
+            feePercentage,
+            name,
+            symbol,
+            INITIAL_DELAY,
+            VAULT_ADMIN,
+            salt,
+            marketsArgs,
+            MIN_INITIAL_DEPOSIT
         );
 
         require(address(vault) != address(vault2), "different deployment address");

--- a/test/helpers/VaultSharedSetup.sol
+++ b/test/helpers/VaultSharedSetup.sol
@@ -44,7 +44,7 @@ contract VaultSharedSetup is IonPoolSharedSetup {
     address constant FEE_RECIPIENT = address(uint160(uint256(keccak256("FEE_RECIPIENT"))));
     uint256 constant ZERO_FEES = 0;
 
-    uint256 constant MIN_INITIAL_DEPOSIT = 1e9;
+    uint256 constant MIN_INITIAL_DEPOSIT = 1e3;
 
     bytes32 constant SALT = keccak256("SALT");
 

--- a/test/unit/concrete/vault/Vault.t.sol
+++ b/test/unit/concrete/vault/Vault.t.sol
@@ -25,7 +25,9 @@ contract VaultSetUpTest is VaultSharedSetup {
     }
 
     function test_AddSupportedMarketsSeparately() public {
-        vault = new Vault(BASE_ASSET, FEE_RECIPIENT, ZERO_FEES, "Ion Vault Token", "IVT", INITIAL_DELAY, VAULT_ADMIN);
+        vault = new Vault(
+            BASE_ASSET, FEE_RECIPIENT, ZERO_FEES, "Ion Vault Token", "IVT", INITIAL_DELAY, VAULT_ADMIN, emptyMarketsArgs
+        );
 
         vm.startPrank(vault.defaultAdmin());
         vault.grantRole(vault.OWNER_ROLE(), OWNER);
@@ -87,7 +89,9 @@ contract VaultSetUpTest is VaultSharedSetup {
     }
 
     function test_AddSupportedMarketsTogether() public {
-        vault = new Vault(BASE_ASSET, FEE_RECIPIENT, ZERO_FEES, "Ion Vault Token", "IVT", INITIAL_DELAY, VAULT_ADMIN);
+        vault = new Vault(
+            BASE_ASSET, FEE_RECIPIENT, ZERO_FEES, "Ion Vault Token", "IVT", INITIAL_DELAY, VAULT_ADMIN, emptyMarketsArgs
+        );
 
         vm.startPrank(vault.defaultAdmin());
         vault.grantRole(vault.OWNER_ROLE(), OWNER);
@@ -1128,7 +1132,9 @@ abstract contract VaultWithIdlePool is VaultSharedSetup {
     function setUp() public virtual override {
         super.setUp();
 
-        vault = new Vault(BASE_ASSET, FEE_RECIPIENT, ZERO_FEES, "Ion Vault Token", "IVT", INITIAL_DELAY, VAULT_ADMIN);
+        vault = new Vault(
+            BASE_ASSET, FEE_RECIPIENT, ZERO_FEES, "Ion Vault Token", "IVT", INITIAL_DELAY, VAULT_ADMIN, emptyMarketsArgs
+        );
 
         BASE_ASSET.approve(address(vault), type(uint256).max);
 

--- a/test/unit/fuzz/vault/Vault.t.sol
+++ b/test/unit/fuzz/vault/Vault.t.sol
@@ -124,8 +124,9 @@ contract VaultWithYieldAndFee_Fuzz is VaultSharedSetup {
         // expected resulting state
 
         uint256 expectedFeeAssets = interestAccrued.mulDiv(feePerc, RAY);
-        uint256 expectedFeeShares =
-            expectedFeeAssets.mulDiv(vault.totalSupply(), newTotalAssets - expectedFeeAssets, Math.Rounding.Floor);
+        uint256 expectedFeeShares = expectedFeeAssets.mulDiv(
+            vault.totalSupply() + 1, newTotalAssets - expectedFeeAssets + 1, Math.Rounding.Floor
+        );
 
         uint256 expectedUserAssets = prevUserAssets + interestAccrued.mulDiv(RAY - feePerc, RAY);
 


### PR DESCRIPTION
- Merges into #95 
- With the virtual assets and virtual shares in the OZ ERC4626, It is still provably unprofitable for the attacker to grief a user deposit. The attacker will lose more money than they gain. But before this change, it was still possible for the attacker to cause the user to lose funds for some cost paid by the attacker. 
    - To further defend against inflation attacks, the factory now enforces the deployer to make an initial deposit of minimum 1e3, and burns 1e3 of the minted shares by locking it in the factory contract.
### Changes
- [x] The `Vault` constructor now calls `_addSupportedMarkets` to allow for initial deposit from the factory.
- [x] Public functions such as `addSupportedMarkets` is separated into `external` and `internal` markets. 
- [x] The factory transfers from the user and deposits into the vault. 