### PR TITLE
[FIX] Avoid InvalidMintAmount revert in Vault when supplying in loop

### DIFF
--- a/test/helpers/VaultSharedSetup.sol
+++ b/test/helpers/VaultSharedSetup.sol
@@ -68,6 +68,9 @@ contract VaultSharedSetup is IonPoolSharedSetup {
 
     address constant NULL = address(0);
 
+    bytes32 public constant ION_POOL_SUPPLY_CAP_SLOT =
+        0xceba3d526b4d5afd91d1b752bf1fd37917c20a6daf576bcb41dd1c57c1f67e09;
+
     function setUp() public virtual override {
         super.setUp();
 

--- a/test/unit/concrete/vault/Vault.t.sol
+++ b/test/unit/concrete/vault/Vault.t.sol
@@ -164,7 +164,23 @@ contract VaultSetUpTest is VaultSharedSetup {
         vm.stopPrank();
     }
 
-    function test_Revert_AddSupportedMarkets_MarketAlreadySupported() public { }
+    function test_Revert_AddSupportedMarkets_MarketAlreadySupported() public {
+        IIonPool[] memory newMarkets = new IIonPool[](1);
+        newMarkets[0] = weEthIonPool;
+
+        uint256[] memory newAllocationCaps = new uint256[](1);
+        newAllocationCaps[0] = 1e18;
+
+        IIonPool[] memory queue = new IIonPool[](4);
+        queue[0] = weEthIonPool;
+        queue[1] = rsEthIonPool;
+        queue[2] = rswEthIonPool;
+        queue[3] = weEthIonPool;
+
+        vm.startPrank(OWNER);
+        vm.expectRevert(abi.encodeWithSelector(Vault.MarketAlreadySupported.selector, weEthIonPool));
+        vault.addSupportedMarkets(newMarkets, newAllocationCaps, queue, queue);
+    }
 
     function test_Revert_AddSupportedMarkets_MaxSupportedMarketsReached() public {
         vault = new Vault(
@@ -452,11 +468,82 @@ contract VaultSetUpTest is VaultSharedSetup {
         vault.updateSupplyQueue(notSupportedQueue);
     }
 
-    function test_UpdateWithdrawQueue() public { }
+    function test_UpdateSupplyQueue_Revert_DuplicateIonPool() public {
+        IIonPool[] memory duplicateQueue = new IIonPool[](3);
+        duplicateQueue[0] = weEthIonPool;
+        duplicateQueue[1] = rswEthIonPool;
+        duplicateQueue[2] = weEthIonPool;
 
-    function test_Revert_UpdateWithdrawQueue() public { }
+        vm.startPrank(OWNER);
+        vm.expectRevert(Vault.InvalidQueueContainsDuplicates.selector);
+        vault.updateSupplyQueue(duplicateQueue);
+    }
 
-    function test_Revert_DuplicateIonPoolArray() public { }
+    function test_UpdateWithdrawQueue() public {
+        IIonPool[] memory withdrawQueue = new IIonPool[](3);
+        withdrawQueue[0] = rsEthIonPool;
+        withdrawQueue[1] = rswEthIonPool;
+        withdrawQueue[2] = weEthIonPool;
+
+        vm.startPrank(OWNER);
+        vault.updateWithdrawQueue(withdrawQueue);
+
+        assertEq(address(vault.withdrawQueue(0)), address(withdrawQueue[0]), "updated withdraw queue");
+        assertEq(address(vault.withdrawQueue(1)), address(withdrawQueue[1]), "updated withdraw queue");
+        assertEq(address(vault.withdrawQueue(2)), address(withdrawQueue[2]), "updated withdraw queue");
+    }
+
+    function test_UpdateWithdrawQueue_Revert_InvalidQueueLength() public {
+        IIonPool[] memory smallerQueue = new IIonPool[](2);
+        smallerQueue[0] = rsEthIonPool;
+        smallerQueue[1] = rswEthIonPool;
+
+        vm.startPrank(OWNER);
+        vm.expectRevert(abi.encodeWithSelector(Vault.InvalidQueueLength.selector, 2, 3));
+        vault.updateWithdrawQueue(smallerQueue);
+
+        IIonPool[] memory biggerQueue = new IIonPool[](4);
+        biggerQueue[0] = rsEthIonPool;
+        biggerQueue[1] = rswEthIonPool;
+
+        vm.startPrank(OWNER);
+        vm.expectRevert(abi.encodeWithSelector(Vault.InvalidQueueLength.selector, 4, 3));
+        vault.updateWithdrawQueue(biggerQueue);
+    }
+
+    function test_UpdateWithdrawQueue_Revert_MarketNotSupported_IonPoolNotSupported() public {
+        IIonPool wrongIonPool = IIonPool(address(uint160(uint256(keccak256("address not in supported markets")))));
+        IIonPool[] memory queue = new IIonPool[](3);
+        queue[0] = rsEthIonPool;
+        queue[1] = rswEthIonPool;
+        queue[2] = wrongIonPool;
+
+        vm.startPrank(OWNER);
+        vm.expectRevert(abi.encodeWithSelector(Vault.MarketNotSupported.selector, wrongIonPool));
+        vault.updateWithdrawQueue(queue);
+    }
+
+    function test_UpdateWithdrawQueue_Revert_MarketNotSupported_ZeroAddress() public {
+        IIonPool[] memory queue = new IIonPool[](3);
+        queue[0] = IIonPool(address(0));
+        queue[1] = rswEthIonPool;
+        queue[2] = weEthIonPool;
+
+        vm.startPrank(OWNER);
+        vm.expectRevert(abi.encodeWithSelector(Vault.MarketNotSupported.selector, address(0)));
+        vault.updateWithdrawQueue(queue);
+    }
+
+    function test_UpdateWithdrawQueue_Revert_DuplicateIonPool() public {
+        IIonPool[] memory duplicateQueue = new IIonPool[](3);
+        duplicateQueue[0] = weEthIonPool;
+        duplicateQueue[1] = rswEthIonPool;
+        duplicateQueue[2] = weEthIonPool;
+
+        vm.startPrank(OWNER);
+        vm.expectRevert(Vault.InvalidQueueContainsDuplicates.selector);
+        vault.updateWithdrawQueue(duplicateQueue);
+    }
 
     function test_UpdateFeePercentage() public {
         vm.prank(OWNER);
@@ -472,6 +559,13 @@ contract VaultSetUpTest is VaultSharedSetup {
         vault.updateFeeRecipient(newFeeRecipient);
 
         assertEq(newFeeRecipient, vault.feeRecipient(), "fee recipient");
+    }
+
+    function test_UpdateFeeRecipient_Revert_ZeroAddress() public {
+        address zeroAddress = address(0);
+        vm.prank(OWNER);
+        vm.expectRevert(Vault.InvalidFeeRecipient.selector);
+        vault.updateFeeRecipient(zeroAddress);
     }
 }
 
@@ -779,7 +873,98 @@ abstract contract VaultDeposit is VaultSharedSetup {
         vault.deposit(depositAmount, address(this));
     }
 
-    function test_SupplyToIonPool_AllocationCapAndSupplyCapDiffs() public { }
+    // allocation cap diff less than supply cap diff
+    // Allocation Cap: 10 out of 15 (room = 5)
+    // Supply Cap: 10 out of 20 (room = 10)
+    // Depositing 7e18 should deposit 5e18 to the first pool, and deposit the rest to the second
+    function test_SupplyToIonPool_AllocationCapDiffBelowSupplyCapDiff() public {
+        uint256 allocationCap = 15e18;
+        uint256 supplyCap = 20e18;
+
+        updateAllocationCaps(vault, allocationCap, type(uint256).max, type(uint256).max);
+        updateSupplyCaps(vault, supplyCap, type(uint256).max, type(uint256).max);
+
+        uint256 initialDeposit = 10e18;
+        deal(address(BASE_ASSET), address(this), initialDeposit);
+        vault.deposit(initialDeposit, address(this));
+
+        uint256 initialIonPoolClaim = vault.supplyQueue(0).balanceOf(address(vault));
+        uint256 firstIonPoolRoundingError = vault.supplyQueue(0).supplyFactor() / RAY + 1;
+        assertLe(initialDeposit - initialIonPoolClaim, firstIonPoolRoundingError, "vault has initial ionPool claim");
+
+        uint256 depositAmt = 7e18;
+        deal(address(BASE_ASSET), address(this), depositAmt);
+        vault.deposit(depositAmt, address(this));
+
+        uint256 resultingFirstIonPoolClaim = vault.supplyQueue(0).balanceOf(address(vault));
+        assertLe(allocationCap - resultingFirstIonPoolClaim, firstIonPoolRoundingError, "vault resulting ionPool claim");
+
+        uint256 secondIonPoolRoundingError = vault.supplyQueue(1).supplyFactor() / RAY + 1;
+        uint256 resultingSecondIonPoolClaim = vault.supplyQueue(1).balanceOf(address(vault));
+        uint256 expectedSecondIonPoolClaim = initialDeposit + depositAmt - allocationCap;
+        assertLe(
+            expectedSecondIonPoolClaim - resultingSecondIonPoolClaim,
+            secondIonPoolRoundingError,
+            "vault second ionPool claim"
+        );
+    }
+
+    // Supply cap diff less than allocation cap diff
+    // Allocation Cap: 10e18 out of 35e18 (room = 25e18)
+    // Supply Cap: 30e18 out of 45e18 (room = 15e18)
+    // Depositing 20e18 should deposit 15e18 to the first pool, then deposit 5 to the next.
+    function test_SupplyToIonPool_SupplyCapDiffBelowAllocationCapDiff() public {
+        uint256 initialTotalSupply = 20e18; // becomes 30 with the `initialDeposit`
+        uint256 initialDeposit = 10e18;
+
+        uint256 allocationCap = 35e18;
+        uint256 supplyCap = 45e18;
+
+        uint256 depositAmt = 20e18;
+
+        updateAllocationCaps(vault, allocationCap, type(uint256).max, type(uint256).max);
+        updateSupplyCaps(vault, supplyCap, type(uint256).max, type(uint256).max);
+
+        // Initialize total supply in first ionPool
+        deal(address(BASE_ASSET), address(this), initialTotalSupply);
+        BASE_ASSET.approve(address(vault.supplyQueue(0)), initialTotalSupply);
+        vault.supplyQueue(0).supply(address(this), initialTotalSupply, new bytes32[](0));
+        uint256 firstIonPoolRoundingError = vault.supplyQueue(0).supplyFactor() / RAY + 1;
+        assertApproxEqAbs(
+            vault.supplyQueue(0).totalSupply(),
+            initialTotalSupply,
+            firstIonPoolRoundingError,
+            "first ionPool has initial total supply"
+        );
+
+        // Initialize vault's first deposit into the first ionPool (separate from the initial total supply)
+        deal(address(BASE_ASSET), address(this), initialDeposit);
+        vault.deposit(initialDeposit, address(this));
+
+        uint256 initialIonPoolClaim = vault.supplyQueue(0).balanceOf(address(vault));
+        assertLe(initialDeposit - initialIonPoolClaim, firstIonPoolRoundingError, "vault has initial ionPool claim");
+
+        // The resulting supply cap should be filled.
+        uint256 totalSupplyBeforeDeposit = vault.supplyQueue(0).totalSupply();
+        uint256 supplyCapBeforeDeposit = uint256(vm.load(address(vault.supplyQueue(0)), ION_POOL_SUPPLY_CAP_SLOT));
+        uint256 supplyCapDiff = supplyCapBeforeDeposit - totalSupplyBeforeDeposit;
+
+        deal(address(BASE_ASSET), address(this), depositAmt);
+        vault.deposit(depositAmt, address(this));
+
+        uint256 resultingFirstIonPoolClaim = vault.supplyQueue(0).balanceOf(address(vault));
+        // the resulting first ionpool claim should be 10 (initialDeposit) + 15 (out of depositAmt)
+        assertLe(25e18 - resultingFirstIonPoolClaim, firstIonPoolRoundingError, "vault resulting ionPool claim");
+
+        uint256 resultingSecondIonPoolClaim = vault.supplyQueue(1).balanceOf(address(vault));
+        uint256 expectedSecondIonPoolClaim = depositAmt - supplyCapDiff;
+        uint256 secondIonPoolRoundingError = vault.supplyQueue(1).supplyFactor() / RAY + 1;
+        assertLe(
+            expectedSecondIonPoolClaim - resultingSecondIonPoolClaim,
+            secondIonPoolRoundingError,
+            "vault second ionPool claim"
+        );
+    }
 
     /**
      * - Exact shares to mint must be minted to the user.
@@ -861,12 +1046,83 @@ abstract contract VaultDeposit is VaultSharedSetup {
         vault.deposit(depositAmt, address(this));
     }
 
-    function test_Mint_AllMarkets() public { }
+    function test_Deposit_Revert_AllSupplyCapsReachedWithAllocationCap() public {
+        updateAllocationCaps(vault, 10 ether, 10 ether, 10 ether);
+
+        uint256 depositAmt = 30 ether + 1;
+        deal(address(BASE_ASSET), address(this), depositAmt);
+
+        vm.expectRevert(Vault.AllSupplyCapsReached.selector);
+        vault.deposit(depositAmt, address(this));
+
+        // this should pass
+        vault.deposit(depositAmt - 1, address(this));
+    }
+
+    function test_Deposit_Revert_AllSupplyCapsReachedWithSupplyCap() public {
+        updateAllocationCaps(vault, type(uint256).max, type(uint256).max, type(uint256).max);
+        updateSupplyCaps(vault, 15 ether, 15 ether, 15 ether);
+
+        uint256 depositAmt = 45 ether + 1;
+        deal(address(BASE_ASSET), address(this), depositAmt);
+
+        vm.expectRevert(Vault.AllSupplyCapsReached.selector);
+        vault.deposit(depositAmt, address(this));
+
+        // this should pass
+        vault.deposit(depositAmt - 1, address(this));
+    }
+
+    /**
+     * Supplying an amount small enough to the IonPool that truncates to mint
+     * zero shares will revert. The `Vault` contract handles this by keeping
+     * this dust amount that was already transferred in on the IDLE balance.
+     */
+    function test_Deposit_IonPoolInvalidMintAmountWithoutIteration() public {
+        updateAllocationCaps(vault, type(uint256).max, type(uint256).max, type(uint256).max);
+
+        uint256 depositAmt = 1; // 1 wei
+        deal(address(BASE_ASSET), address(this), depositAmt);
+        vault.deposit(depositAmt, address(this));
+
+        uint256 expectedTotalAssets;
+        uint256 expectedVaultIdleBalance;
+        uint256 expectedVaultIonPoolBalance;
+
+        IIonPool pool = vault.supplyQueue(0);
+        if (depositAmt.mulDiv(RAY, pool.supplyFactor()) == 0) {
+            expectedTotalAssets = 0;
+            expectedVaultIdleBalance = depositAmt;
+            expectedVaultIonPoolBalance = 0;
+        } else {
+            expectedTotalAssets = depositAmt;
+            expectedVaultIdleBalance = 0;
+            expectedVaultIonPoolBalance = depositAmt;
+        }
+
+        assertEq(BASE_ASSET.balanceOf(address(vault)), expectedVaultIdleBalance, "vault base asset balance");
+        assertEq(vault.totalAssets(), expectedTotalAssets, "vault total assets");
+
+        // No deposit was actually made to the underlying IonPool
+        assertEq(pool.balanceOf(address(vault)), expectedVaultIonPoolBalance, "IonPool balance");
+    }
+
+    function test_Deposit_IonPoolInvalidMintAmountWithIteration() public { }
+
+    /**
+     * If the try catch encounters an error that is not `InvalidMintAmount`, it
+     * should simply skip the iteration.
+     */
+    function test_Deposit_IonPoolThrowsUnrecognizedError() public { }
 }
 
 abstract contract VaultWithdraw is VaultSharedSetup {
     function setUp() public virtual override {
         super.setUp();
+    }
+
+    function test_Withdraw_SenderIsNotTheOwner() public {
+        // TODO
     }
 
     function test_Withdraw_SingleMarket() public {
@@ -1032,6 +1288,27 @@ abstract contract VaultWithdraw is VaultSharedSetup {
             rswEthIonPool.supplyFactor() / RAY,
             "rswEthIonPool balance"
         );
+    }
+
+    /**
+     * Case where the last remaining asset being withdrawn would lead to
+     * InvalidBurnAmount error. This should revert if there are no IDLE assets
+     * to be withdrawn.
+     */
+    function test_Withdraw_InvalidBurnAmountAtTheLastWithdraw() public {
+        updateAllocationCaps(vault, 1e18, 2e18, 3e18);
+
+        uint256 depositAmt = vault.maxDeposit(NULL);
+        deal(address(BASE_ASSET), address(this), depositAmt);
+        vault.deposit(depositAmt, address(this));
+
+        uint256 withdrawable = weEthIonPool.balanceOf(address(vault)); // withdrawable from the first pool
+        // Tries to withdraw 1 more than the withdrawable from the first pool.
+        // This should attempt a 1 wei withdrawal on the second pool.
+        uint256 withdrawAmt = withdrawable + 1;
+
+        require(BASE_ASSET.balanceOf(address(vault)) == 0, "vault IDLE pool is zero");
+        vault.withdraw(withdrawAmt, address(this), address(this));
     }
 
     // try to deposit and withdraw same amounts

--- a/test/unit/fuzz/vault/Vault.t.sol
+++ b/test/unit/fuzz/vault/Vault.t.sol
@@ -13,7 +13,11 @@ import { IERC20 } from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
 using Math for uint256;
 using WadRayMath for uint256;
 
+import { console2 } from "forge-std/console2.sol";
+
 contract Vault_Fuzz is VaultSharedSetup {
+    using Math for uint256;
+
     function setUp() public override {
         super.setUp();
 
@@ -128,16 +132,102 @@ contract Vault_Fuzz is VaultSharedSetup {
         assertLe(resultingTotalClaim, allocationCap, "expected claim le to allocation cap");
         assertLe(actualTotalClaim, allocationCap, "actual claim le to allocation cap");
     }
+
+    /**
+     * Should confirm that maxBound is the true maxBound.
+     * - If maxBound is increased by one, then the equals assert should fail.
+     */
+    function testFuzz_MaximumDepositAmountThatTruncatesToZeroNormalized(uint256 assets, uint256 supplyFactor) public {
+        supplyFactor = bound(supplyFactor, 1e27, type(uint256).max);
+
+        // this amount should always trunate to zero after division
+        // ceil(supplyFactor / RAY) - 1 passes [correctly constrained]
+        // ceil(supplyFactor / RAY) does not pass
+        uint256 divRoundUp = supplyFactor % RAY == 0 ? supplyFactor / RAY : supplyFactor / RAY + 1;
+        uint256 assetsMaxBound = divRoundUp - 1; // supplyFactor / RAY - 1 passes but overconstrained?
+
+        assets = bound(assets, 0, assetsMaxBound);
+
+        uint256 normalized = assets.mulDiv(RAY, supplyFactor);
+
+        assertEq(normalized, 0, "normalized must be zero");
+    }
+
+    /**
+     * Assume `supplyFactor` is less than 2e27.
+     * 1. If `supplyFactor` is 2e27, the maxBound ceil(2e27 / 1e27) - 1 = 1.
+     * This means anything above 1 wei will not truncate to zero.
+     * 2. If `supplyFactor` is 2e27 - 1, the maxBound ceil((2e27 - 1) / 1e27) - 1 is 1.
+     * This means the maxBound is 1. So anything above 1 (i.e. 2 and above)
+     * should not normalize to zero.
+     */
+    function testFuzz_MaximumDepositAmountThatTruncatesWhenSupplyFactorIsLessThanTwoRay(
+        uint256 assets,
+        uint256 supplyFactor
+    )
+        public
+    {
+        supplyFactor = bound(supplyFactor, 1e27, 2e27);
+        assets = bound(assets, 2, type(uint256).max);
+
+        // all assets amount other than 0 will NOT truncate to zero.
+        uint256 normalized = assets.mulDiv(RAY, supplyFactor);
+
+        assertTrue(normalized != 0, "normalized must NOT be zero");
+    }
+
+    /**
+     * If `assets` is not 0, then the result of the muldiv should never be 0 due
+     * to the ceiling.
+     */
+    function testFuzz_MulDivCeilingCanNotBeZero(uint256 assets, uint256 supplyFactor) public {
+        assets = bound(assets, 1, type(uint128).max);
+        supplyFactor = bound(supplyFactor, 1, type(uint128).max);
+
+        uint256 result = assets.mulDiv(RAY, supplyFactor, Math.Rounding.Ceil);
+
+        assertTrue(result != 0, "result must NOT be zero");
+    }
 }
 
-contract VaultWithYieldAndFee_Fuzz is VaultSharedSetup {
+contract VaultWithYieldAndFeeSharedSetup is VaultSharedSetup {
     uint256 constant INITIAL_SUPPLY_AMT = 1000e18;
+    uint256 constant MAX_DAYS = 10_000 days;
+    uint256 constant MINIMUM_FEE_PERC = 0.02e27;
+    uint256 constant MAXIMUM_FEE_PERC = 1e27;
 
-    function setUp() public override {
+    uint256 constant MINIMUM_INITIAL_DEPOSIT = 0;
+    uint256 constant MAXIMUM_INITIAL_DEPOSIT = type(uint128).max;
+
+    IIonPool[] internal queue = new IIonPool[](4);
+
+    function setUp() public virtual override {
         super.setUp();
 
-        uint256 initialSupplyAmt = 1000e18;
+        IIonPool[] memory marketsToAdd = new IIonPool[](1);
+        marketsToAdd[0] = IDLE;
 
+        uint256[] memory newMarketAllocationCap = new uint256[](1);
+        newMarketAllocationCap[0] = 0;
+
+        queue[0] = IDLE;
+        queue[1] = weEthIonPool;
+        queue[2] = rsEthIonPool;
+        queue[3] = rswEthIonPool;
+
+        vm.prank(OWNER);
+        vault.addSupportedMarkets(marketsToAdd, newMarketAllocationCap, queue, queue);
+
+        uint256[] memory allocationCaps = new uint256[](4);
+        allocationCaps[0] = 10e18;
+        allocationCaps[1] = 20e18;
+        allocationCaps[2] = 30e18;
+        allocationCaps[3] = 40e18;
+
+        vm.prank(OWNER);
+        vault.updateAllocationCaps(queue, allocationCaps);
+
+        // Setup IonPools
         weEthIonPool.updateSupplyCap(type(uint256).max);
         rsEthIonPool.updateSupplyCap(type(uint256).max);
         rswEthIonPool.updateSupplyCap(type(uint256).max);
@@ -154,15 +244,10 @@ contract VaultWithYieldAndFee_Fuzz is VaultSharedSetup {
 
         supply(address(this), rswEthIonPool, INITIAL_SUPPLY_AMT);
         borrow(address(this), rswEthIonPool, rswEthGemJoin, 100e18, 70e18);
-
-        uint256 weEthIonPoolCap = 10e18;
-        uint256 rsEthIonPoolCap = 20e18;
-        uint256 rswEthIonPoolCap = 30e18;
-
-        vm.prank(OWNER);
-        updateAllocationCaps(vault, weEthIonPoolCap, rsEthIonPoolCap, rswEthIonPoolCap);
     }
+}
 
+contract VaultWithYieldAndFee_Fuzz_FeeAccrual is VaultWithYieldAndFeeSharedSetup {
     function testFuzz_AccruedFeeShares(uint256 initialDeposit, uint256 feePerc, uint256 daysAccrued) public {
         // fee percentage
         feePerc = bound(feePerc, 0, RAY - 1);
@@ -172,7 +257,7 @@ contract VaultWithYieldAndFee_Fuzz is VaultSharedSetup {
 
         // initial deposit
         uint256 initialMaxDeposit = vault.maxDeposit(NULL);
-        initialDeposit = bound(initialDeposit, 1e18, initialMaxDeposit);
+        initialDeposit = bound(initialDeposit, 15e18, initialMaxDeposit);
 
         setERC20Balance(address(BASE_ASSET), address(this), initialDeposit);
         vault.deposit(initialDeposit, address(this));
@@ -183,7 +268,7 @@ contract VaultWithYieldAndFee_Fuzz is VaultSharedSetup {
         uint256 prevUserAssets = vault.previewRedeem(prevUserShares);
 
         // interest accrues over a year
-        daysAccrued = bound(daysAccrued, 1, 10_000 days);
+        daysAccrued = bound(daysAccrued, 1, MAX_DAYS);
         vm.warp(block.timestamp + daysAccrued);
 
         (uint256 totalSupplyFactorIncrease,,,,) = weEthIonPool.calculateRewardAndDebtDistribution();
@@ -240,10 +325,505 @@ contract VaultWithYieldAndFee_Fuzz is VaultSharedSetup {
         assertEq(userShares + feeRecipientShares, vault.totalSupply(), "vault total supply");
         assertLe(vault.totalAssets() - (userAssets + feeRecipientAssets), 2, "vault total assets");
     }
+}
 
-    function testFuzz_MaxWithdrawAndMaxRedeem(uint256 assets) public { }
+contract VaultWithYieldAndFee_Fuzz_Previews_SinglePool is VaultWithYieldAndFeeSharedSetup {
+    function setUp() public override {
+        super.setUp();
 
-    function testFuzz_MaxDepositAndMaxMint(uint256 assets) public { }
+        // Only funnel deposits into one IonPool that's not IDLE.
+        uint256[] memory allocationCaps = new uint256[](4);
+        allocationCaps[0] = 0;
+        allocationCaps[1] = type(uint128).max;
+        allocationCaps[2] = 0;
+        allocationCaps[3] = 0;
+
+        vm.prank(OWNER);
+        vault.updateAllocationCaps(queue, allocationCaps);
+    }
+
+    function testFuzz_previewDeposit_SinglePool(
+        uint256 assets,
+        uint256 feePerc,
+        uint256 daysAccrued,
+        uint256 supplyFactor
+    )
+        public
+    {
+        // 1. Set `supplyFactor`
+        supplyFactor = bound(supplyFactor, 1e27, 10e27);
+        IonPoolExposed(address(weEthIonPool)).setSupplyFactor(supplyFactor);
+
+        // 2. Make initial vault deposit
+        uint256 initialDeposit = bound(assets, MINIMUM_INITIAL_DEPOSIT, vault.maxDeposit(NULL));
+        deal(address(BASE_ASSET), address(this), initialDeposit);
+        vault.deposit(initialDeposit, address(this));
+
+        // 3. Set fee percentage
+        feePerc = bound(feePerc, MINIMUM_FEE_PERC, MAXIMUM_FEE_PERC);
+
+        vm.prank(OWNER);
+        vault.updateFeePercentage(feePerc);
+
+        // 4. Accrue interest
+        daysAccrued = bound(daysAccrued, 100 days, MAX_DAYS);
+        vm.warp(block.timestamp + daysAccrued);
+
+        // 5. Compare preview deposit with real deposit
+        // - Minimum deposit amount is amount that won't be truncated by zer
+        // - amt * RAY / supplyFactor > 0
+        uint256 minimumDeposit = RAY / vault.supplyQueue(1).supplyFactor() + 1;
+        uint256 previewDepositAmt = bound(assets, 0, vault.maxDeposit(NULL));
+
+        console2.log("vault.maxDeposit(NULL): ", vault.maxDeposit(NULL));
+        console2.log("previewDepositAmt: ", previewDepositAmt);
+
+        console2.log("--- preview deposit ---");
+        uint256 expectedShares = vault.previewDeposit(previewDepositAmt);
+        console2.log("--- preview deposit done ---");
+
+        deal(address(BASE_ASSET), address(this), previewDepositAmt);
+        uint256 resultingShares = vault.deposit(previewDepositAmt, address(this));
+
+        uint256 resultingAssets = vault.previewRedeem(resultingShares);
+
+        uint256 resultingAssetsRoundingError = vault.supplyQueue(1).supplyFactor() / RAY + 1;
+
+        assertEq(BASE_ASSET.balanceOf(address(this)), 0, "resulting user asset balance");
+        assertEq(resultingShares, expectedShares, "resulting shares must be equal to expected shares");
+        assertApproxEqAbs(
+            resultingAssets, previewDepositAmt, resultingAssetsRoundingError, "resulting assets with rounding error"
+        );
+    }
+
+    function testFuzz_previewMint_SinglePool(
+        uint256 assets,
+        uint256 feePerc,
+        uint256 daysAccrued,
+        uint256 supplyFactor
+    )
+        public
+    {
+        // 1. Set `supplyFactor`
+        supplyFactor = bound(supplyFactor, 1e27, 10e27);
+        IonPoolExposed(address(weEthIonPool)).setSupplyFactor(supplyFactor);
+
+        // 2. Make initial vault deposit
+        uint256 initialDeposit = bound(assets, MINIMUM_INITIAL_DEPOSIT, vault.maxDeposit(NULL));
+        deal(address(BASE_ASSET), address(this), initialDeposit);
+        vault.deposit(initialDeposit, address(this));
+
+        // 3. Set fee percentage
+        feePerc = bound(feePerc, MINIMUM_FEE_PERC, MAXIMUM_FEE_PERC);
+
+        // 4. Accrue interest
+        daysAccrued = bound(daysAccrued, 100 days, MAX_DAYS);
+        vm.warp(block.timestamp + daysAccrued);
+
+        // 5. Compare `previewMint` with `mint`
+
+        uint256 previewMintAmt = bound(assets, 0, vault.maxMint(NULL));
+
+        uint256 expectedAssets = vault.previewMint(previewMintAmt);
+
+        uint256 prevShares = vault.balanceOf(address(this));
+
+        deal(address(BASE_ASSET), address(this), expectedAssets);
+        uint256 resultingAssets = vault.mint(previewMintAmt, address(this));
+
+        uint256 sharesDiff = vault.balanceOf(address(this)) - prevShares;
+
+        assertEq(BASE_ASSET.balanceOf(address(this)), 0, "resulting user asset balance");
+        assertEq(resultingAssets, expectedAssets, "resulting assets must be equal to expected assets");
+        assertEq(sharesDiff, previewMintAmt, "resulting shares must be equal to preview mint amount");
+    }
+
+    function testFuzz_previewWithdraw_SinglePool(
+        uint256 assets,
+        uint256 feePerc,
+        uint256 daysAccrued,
+        uint256 supplyFactor
+    )
+        public
+    {
+        // 1. Set `supplyFactor`
+        supplyFactor = bound(supplyFactor, 1e27, 10e27);
+        IonPoolExposed(address(weEthIonPool)).setSupplyFactor(supplyFactor);
+
+        // 2. Make initial vault deposit
+        require(vault.maxDeposit(NULL) > 0);
+        uint256 initialDeposit = bound(assets, MINIMUM_INITIAL_DEPOSIT, vault.maxDeposit(NULL));
+        deal(address(BASE_ASSET), address(this), initialDeposit);
+        vault.deposit(initialDeposit, address(this));
+
+        // require(vault.balanceOf(address(this)) > 0, 'shares minted');
+
+        // 3. Set fee percentage
+        feePerc = bound(feePerc, MINIMUM_FEE_PERC, MAXIMUM_FEE_PERC);
+
+        // 4. Accrue interest
+        daysAccrued = bound(daysAccrued, 100 days, MAX_DAYS);
+        vm.warp(block.timestamp + daysAccrued);
+
+        // 5. Compoare `previewWithdraw` and `withdraw`
+        uint256 previewWithdrawAmt = bound(assets, 0, vault.maxWithdraw(address(this)));
+        uint256 expectedShares = vault.previewWithdraw(previewWithdrawAmt);
+
+        uint256 prevShares = vault.balanceOf(address(this));
+        uint256 prevBalance = BASE_ASSET.balanceOf(address(this));
+
+        uint256 resultingShares = vault.withdraw(previewWithdrawAmt, address(this), address(this));
+
+        uint256 sharesDiff = prevShares - vault.balanceOf(address(this));
+        uint256 balanceDiff = BASE_ASSET.balanceOf(address(this)) - prevBalance;
+
+        assertEq(sharesDiff, resultingShares, "actual shares diff should be equal to the returned shares");
+        assertEq(resultingShares, expectedShares, "resulting shares must be equal to preview shares");
+        assertEq(balanceDiff, previewWithdrawAmt, "resulting balance should be the exact request withdraw amount");
+    }
+
+    function testFuzz_previewRedeem_SinglePool(
+        uint256 assets,
+        uint256 feePerc,
+        uint256 daysAccrued,
+        uint256 supplyFactor
+    )
+        public
+    {
+        // 1. Set `supplyFactor`
+        supplyFactor = bound(supplyFactor, 1e27, 10e27);
+        IonPoolExposed(address(weEthIonPool)).setSupplyFactor(supplyFactor);
+
+        // 2. Make initial vault deposit
+        uint256 initialDeposit = bound(assets, MINIMUM_INITIAL_DEPOSIT, vault.maxDeposit(NULL));
+        deal(address(BASE_ASSET), address(this), initialDeposit);
+        vault.deposit(initialDeposit, address(this));
+
+        // 3. Set fee percentage
+        feePerc = bound(feePerc, MINIMUM_FEE_PERC, MAXIMUM_FEE_PERC);
+
+        // 4. Accrue interest
+        daysAccrued = bound(daysAccrued, 100 days, MAX_DAYS);
+        vm.warp(block.timestamp + daysAccrued);
+
+        // 5. Compare `previewRedeem` and `redeem`
+        uint256 prevShares = vault.balanceOf(address(this));
+
+        uint256 previewRedeemAmt = bound(assets, 0, vault.maxRedeem(address(this)));
+        uint256 expectedAssets = vault.previewRedeem(previewRedeemAmt);
+
+        uint256 resultingAssets = vault.redeem(previewRedeemAmt, address(this), address(this));
+
+        uint256 sharesDiff = prevShares - vault.balanceOf(address(this));
+
+        assertEq(resultingAssets, expectedAssets, "resulting assets must be equal to expected assets");
+        assertEq(sharesDiff, previewRedeemAmt, "shares burned must be equal to redeem amount");
+    }
+}
+
+contract VaultWithYieldAndFee_Fuzz_Previews_MultiplePools is VaultWithYieldAndFeeSharedSetup {
+    /**
+     * Fuzz variables
+     * - `supplyFactor`
+     * - `newTotalAssets` (through interest accrual)
+     * - `feeShares` minted (through fee percentage)
+     */
+    function testFuzz_previewDeposit_MultiplePools(
+        uint256 assets,
+        uint256 feePerc,
+        uint256 daysAccrued,
+        uint256 supplyFactor
+    )
+        public
+    {
+        // preview deposit and try to mint those shares.
+        // compare `previewDeposit` with actual minted amounts.
+
+        // 1. Set `supplyFactor`
+        supplyFactor = bound(supplyFactor, 1e27, 10e27);
+        IonPoolExposed(address(weEthIonPool)).setSupplyFactor(supplyFactor);
+
+        supplyFactor = bound(supplyFactor, 1e27, 10e27);
+        IonPoolExposed(address(rsEthIonPool)).setSupplyFactor(supplyFactor);
+
+        supplyFactor = bound(supplyFactor, 1e27, 10e27);
+        IonPoolExposed(address(rswEthIonPool)).setSupplyFactor(supplyFactor);
+
+        uint256 firstRoundingError = weEthIonPool.supplyFactor() / RAY + 1;
+        uint256 secondRoundingError = rsEthIonPool.supplyFactor() / RAY + 1;
+        uint256 thirdRoundingError = rswEthIonPool.supplyFactor() / RAY + 1;
+        uint256 roundingError = firstRoundingError + secondRoundingError + thirdRoundingError;
+
+        // 1. Set fee percentage
+        feePerc = bound(feePerc, 0, RAY - 1);
+
+        vm.prank(OWNER);
+        vault.updateFeePercentage(feePerc);
+
+        // 2. Accrue interest
+        daysAccrued = bound(daysAccrued, 1, MAX_DAYS);
+        vm.warp(block.timestamp + daysAccrued);
+
+        require(vault.caps(weEthIonPool) > 0, "weEthIonPool cap");
+        require(vault.caps(rsEthIonPool) > 0, "rsEthIonPool cap");
+        require(vault.caps(rswEthIonPool) > 0, "rswEthIonPool cap");
+
+        // 3. Preview deposit
+        // - Minimum deposit amount is amount that won't be truncated by zer
+        // - amt * RAY / supplyFactor > 0
+        uint256 previewDepositAmt = bound(assets, 0, vault.maxDeposit(NULL));
+        uint256 expectedShares = vault.previewDeposit(previewDepositAmt);
+
+        console2.log("previewDepositAmt: ", previewDepositAmt);
+        console2.log("expectedShares: ", expectedShares);
+
+        deal(address(BASE_ASSET), address(this), previewDepositAmt);
+        uint256 resultingShares = vault.deposit(previewDepositAmt, address(this));
+
+        uint256 resultingAssets = vault.previewRedeem(resultingShares);
+
+        uint256 resultingAssetsRoundingError = supplyFactor / RAY + 1;
+
+        assertEq(BASE_ASSET.balanceOf(address(this)), 0, "resulting user asset balance");
+        assertEq(
+            resultingShares, expectedShares, "resulting shares minted must be equal to shares from preview deposit."
+        );
+        assertApproxEqAbs(
+            resultingAssets,
+            previewDepositAmt,
+            roundingError,
+            "resulting assets must be equal to preview deposit amount"
+        );
+    }
+
+    function testFuzz_previewMint_MultiplePools(
+        uint256 assets,
+        uint256 feePerc,
+        uint256 daysAccrued,
+        uint256 supplyFactor
+    )
+        public
+    {
+        // 1. Set `supplyFactor`
+        supplyFactor = bound(supplyFactor, 1e27, 10e27);
+        IonPoolExposed(address(weEthIonPool)).setSupplyFactor(supplyFactor);
+
+        supplyFactor = bound(supplyFactor, 1e27, 10e27);
+        IonPoolExposed(address(rsEthIonPool)).setSupplyFactor(supplyFactor);
+
+        supplyFactor = bound(supplyFactor, 1e27, 10e27);
+        IonPoolExposed(address(rswEthIonPool)).setSupplyFactor(supplyFactor);
+
+        uint256 firstRoundingError = weEthIonPool.supplyFactor() / RAY + 1;
+        uint256 secondRoundingError = rsEthIonPool.supplyFactor() / RAY + 1;
+        uint256 thirdRoundingError = rswEthIonPool.supplyFactor() / RAY + 1;
+        uint256 roundingError = firstRoundingError + secondRoundingError + thirdRoundingError;
+
+        // 1. Set fee percentage
+        feePerc = bound(feePerc, 0, RAY - 1);
+
+        vm.prank(OWNER);
+        vault.updateFeePercentage(feePerc);
+
+        // 2. Accrue interest
+        daysAccrued = bound(daysAccrued, 1, MAX_DAYS);
+        vm.warp(block.timestamp + daysAccrued);
+
+        // 3. Preview mint
+        uint256 previewMintAmt = bound(assets, 0, vault.maxMint(NULL));
+        console2.log("previewMintAmt: ", previewMintAmt);
+        uint256 expectedAssets = vault.previewMint(previewMintAmt);
+        console2.log("expectedAssets: ", expectedAssets);
+
+        uint256 prevShares = vault.balanceOf(address(this));
+
+        deal(address(BASE_ASSET), address(this), expectedAssets);
+
+        uint256 prevBalance = BASE_ASSET.balanceOf(address(this));
+
+        uint256 resultingAssets = vault.mint(previewMintAmt, address(this));
+
+        console2.log("resultingAssets: ", resultingAssets);
+        console2.log("newBalance: ", BASE_ASSET.balanceOf(address(this)));
+
+        uint256 sharesDiff = vault.balanceOf(address(this)) - prevShares;
+        uint256 balanceDiff = prevBalance - BASE_ASSET.balanceOf(address(this));
+
+        uint256 sharesToRedeem = vault.previewWithdraw(expectedAssets);
+
+        // 1. The `previewMintAmt` must be the change in user's shares.
+        // 2. The `expectedAssets` from the `previewMint` must be the same as
+        // the actual change in user's token balance.
+        // 3. The `previewWithdraw` of the `expectedAssets` from `previewMint` must be the same as `previewMintAmt`.
+
+        assertEq(sharesDiff, previewMintAmt, "shares diff must be equal to preview mint amount");
+        assertEq(expectedAssets, balanceDiff, "expected assets must be equal to balance diff");
+        // assertApproxEqAbs(sharesToRedeem, previewMintAmt, roundingError, "shares to redeem must be equal to preview
+        // mint amount");
+    }
+
+    /**
+     * The edge case of withdraw reverting when withdrawing 1 wei as the last
+     * withdraw action does not revert if there are IDLE balances.
+     */
+    function testFuzz_previewWithdraw_MultiplePools_WithIdleBalance(
+        uint256 assets,
+        uint256 feePerc,
+        uint256 daysAccrued,
+        uint256 supplyFactor
+    )
+        public
+    {
+        // 1. Set `supplyFactor`
+        supplyFactor = bound(supplyFactor, 1e27, 10e27);
+        IonPoolExposed(address(weEthIonPool)).setSupplyFactor(supplyFactor);
+
+        supplyFactor = bound(supplyFactor, 1e27, 10e27);
+        IonPoolExposed(address(rsEthIonPool)).setSupplyFactor(supplyFactor);
+
+        supplyFactor = bound(supplyFactor, 1e27, 10e27);
+        IonPoolExposed(address(rswEthIonPool)).setSupplyFactor(supplyFactor);
+
+        // 1. Set fee percentage
+        feePerc = bound(feePerc, 0, RAY - 1);
+
+        vm.prank(OWNER);
+        vault.updateFeePercentage(feePerc);
+
+        // 2. Make initial vault deposit
+        uint256 initialDeposit = bound(assets, MINIMUM_INITIAL_DEPOSIT, vault.maxDeposit(NULL));
+        deal(address(BASE_ASSET), address(this), initialDeposit);
+        vault.deposit(initialDeposit, address(this));
+
+        // 3. Accrue interest
+        daysAccrued = bound(daysAccrued, 1, MAX_DAYS);
+        vm.warp(block.timestamp + daysAccrued);
+
+        uint256 previewWithdrawAmt = bound(assets, 0, vault.maxWithdraw(address(this)));
+        uint256 expectedShares = vault.previewWithdraw(previewWithdrawAmt);
+
+        uint256 prevBalance = BASE_ASSET.balanceOf(address(this));
+
+        uint256 resultingShares = vault.withdraw(previewWithdrawAmt, address(this), address(this));
+
+        uint256 balanceDiff = BASE_ASSET.balanceOf(address(this)) - prevBalance;
+
+        // 1. Compare the withdrawn assets between the input withdraw assets and
+        // real change in token balance.
+        // 2. Compare the redeemed shares between `previewWithdraw` and `withdraw`
+        assertEq(balanceDiff, previewWithdrawAmt, "balance diff must be equal to preview withdraw amount");
+        assertEq(resultingShares, expectedShares, "resulting shares must be equal to expected shares");
+    }
+
+    /**
+     * The edge case of withdraw reverting when withdrawing 1 wei as the last
+     * withdraw action should revert if there are no IDLE balances.
+     */
+    function testFuzz_previewWithdraw_MultiplePools_WithoutIdleBalance(
+        uint256 assets,
+        uint256 feePerc,
+        uint256 daysAccrued,
+        uint256 supplyFactor
+    )
+        public
+    {
+        // 1. Set `supplyFactor`
+        supplyFactor = bound(supplyFactor, 1e27, 10e27);
+        IonPoolExposed(address(weEthIonPool)).setSupplyFactor(supplyFactor);
+
+        supplyFactor = bound(supplyFactor, 1e27, 10e27);
+        IonPoolExposed(address(rsEthIonPool)).setSupplyFactor(supplyFactor);
+
+        supplyFactor = bound(supplyFactor, 1e27, 10e27);
+        IonPoolExposed(address(rswEthIonPool)).setSupplyFactor(supplyFactor);
+
+        // 1. Set fee percentage
+        feePerc = bound(feePerc, 0, RAY - 1);
+
+        vm.prank(OWNER);
+        vault.updateFeePercentage(feePerc);
+
+        // 2. Make initial vault deposit
+        uint256 initialDeposit = bound(assets, MINIMUM_INITIAL_DEPOSIT, vault.maxDeposit(NULL));
+        deal(address(BASE_ASSET), address(this), initialDeposit);
+        vault.deposit(initialDeposit, address(this));
+
+        // 3. Empty out the IDLE pool.
+        vault.withdraw(BASE_ASSET.balanceOf(address(vault)), address(this), address(this));
+        require(BASE_ASSET.balanceOf(address(vault)) == 0, "empty IDLE balance");
+
+        // 3. Accrue interest
+        daysAccrued = bound(daysAccrued, 1, MAX_DAYS);
+        vm.warp(block.timestamp + daysAccrued);
+
+        console2.log("vault.maxWithdraw(address(this)): ", vault.maxWithdraw(address(this)));
+        uint256 previewWithdrawAmt = bound(assets, 0, vault.maxWithdraw(address(this)));
+        console2.log("previewWithdrawAmt: ", previewWithdrawAmt);
+        uint256 expectedShares = vault.previewWithdraw(previewWithdrawAmt);
+
+        uint256 prevBalance = BASE_ASSET.balanceOf(address(this));
+
+        uint256 resultingShares = vault.withdraw(previewWithdrawAmt, address(this), address(this));
+
+        uint256 balanceDiff = BASE_ASSET.balanceOf(address(this)) - prevBalance;
+
+        // 1. Compare the withdrawn assets between the input withdraw assets and
+        // real change in token balance.
+        // 2. Compare the redeemed shares between `previewWithdraw` and `withdraw`
+        assertEq(balanceDiff, previewWithdrawAmt, "balance diff must be equal to preview withdraw amount");
+        assertEq(resultingShares, expectedShares, "resulting shares must be equal to expected shares");
+    }
+
+    function testFuzz_previewRedeem_MultiplePools(
+        uint256 assets,
+        uint256 feePerc,
+        uint256 daysAccrued,
+        uint256 supplyFactor
+    )
+        public
+    {
+        // 1. Set `supplyFactor`
+        supplyFactor = bound(supplyFactor, 1e27, 10e27);
+        IonPoolExposed(address(weEthIonPool)).setSupplyFactor(supplyFactor);
+
+        supplyFactor = bound(supplyFactor, 1e27, 10e27);
+        IonPoolExposed(address(rsEthIonPool)).setSupplyFactor(supplyFactor);
+
+        supplyFactor = bound(supplyFactor, 1e27, 10e27);
+        IonPoolExposed(address(rswEthIonPool)).setSupplyFactor(supplyFactor);
+
+        // 1. Set fee percentage
+        feePerc = bound(feePerc, 0, RAY - 1);
+
+        vm.prank(OWNER);
+        vault.updateFeePercentage(feePerc);
+
+        // 2. Make initial vault deposit
+        uint256 initialDeposit = bound(assets, MINIMUM_INITIAL_DEPOSIT, vault.maxDeposit(NULL));
+        deal(address(BASE_ASSET), address(this), initialDeposit);
+        vault.deposit(initialDeposit, address(this));
+
+        // 3. Accrue interest
+        daysAccrued = bound(daysAccrued, 1, MAX_DAYS);
+        vm.warp(block.timestamp + daysAccrued);
+
+        uint256 prevShares = vault.balanceOf(address(this));
+        uint256 prevBalance = BASE_ASSET.balanceOf(address(this));
+
+        uint256 previewRedeemAmt = bound(assets, 0, vault.maxRedeem(address(this)));
+        uint256 expectedWithdraw = vault.previewRedeem(previewRedeemAmt);
+
+        uint256 resultingWithdraw = vault.redeem(previewRedeemAmt, address(this), address(this));
+
+        uint256 sharesDiff = prevShares - vault.balanceOf(address(this));
+        uint256 balanceDiff = BASE_ASSET.balanceOf(address(this)) - prevBalance;
+
+        // 1. Compare the change in shares balance with the `previewRedeemAmt`
+        // 2. Compare the resultingWithdrawAmt with the preview expected withdraw amouont.
+        assertEq(sharesDiff, previewRedeemAmt, "shares diff must be equal to preview redeem amount");
+        assertEq(resultingWithdraw, expectedWithdraw, "resulting withdraw must be equal to expected withdraw");
+        assertEq(balanceDiff, resultingWithdraw, "balance diff must be equal to expected withdraw");
+    }
 }
 
 contract VaultInflationAttack is VaultSharedSetup {


### PR DESCRIPTION
## Issue
- In the `_supplyToIonPool` iteration, if the `toSupply` amount is small enoough to normalize to zero, then it throws the `IonPool.InvalidMintAmount` error. 
    - This meant that in some cases, if the user's requested deposit `assets` are being supplied through the loop, and if the last remaining bit to supply led to the `InvalidMintAmount` error, then the loop exited without being able to decrement `assets` down to zero, which reverts the transaction.
    - In this rare case, the user's deposit would have reverted despite having enough available room to deposit.
## Fix
- In the `_supplyToIonPool` iteration, if the `toSupply` amount is small enoough to normalize to zero _**and**_ this `toSupply` is the last remaining bit of the user's requested deposit amount, we skip the supply to avoid the revert. This has the effect of depositing to the `IDLE` pool and not the IonPool specified in the loop. 
- In practice, the maximum amount that `toSupply` can be to truncate to zero when normalized is determined by: 
    - `maxBound = ceil(supplyFactor/ RAY) - 1` 
        - This means that if `supplyFactor` is between `1e27 + 1` and `2e27 - 1`, then `toSupply` needs to be exactly `1`. And in the next range `2e27 ` to `3e27 - 1`, the `toSupply` needs to be exactly `2`. 
        - In practice, since `supplyFactor` will most likely never be above `2e27`, the user will have to deposit an exact amount that ends up depositing exactly `1` wei as its last supply into the `IonPool`.