### PR TITLE
Vault Deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,14 @@
     "10_AdminTransfer:deployment:deploy:anvil": "forge script script/deploy/10_AdminTransfer.s.sol --rpc-url http://localhost:8545 --private-key $PRIVATE_KEY --slow",
     "10_AdminTransfer:deployment:deploy:tenderly": "forge script script/deploy/10_AdminTransfer.s.sol --rpc-url $TENDERLY_RPC_URL --private-key $PRIVATE_KEY --slow",
     "10_AdminTransfer:deployment:deploy:sepolia": "forge script script/deploy/10_AdminTransfer.s.sol --rpc-url $SEPOLIA_RPC_URL --private-key $PRIVATE_KEY --slow",
-    "10_AdminTransfer:deployment:deploy:mainnet": "forge script script/deploy/10_AdminTransfer.s.sol --rpc-url $MAINNET_RPC_URL --private-key $PRIVATE_KEY --slow"
+    "10_AdminTransfer:deployment:deploy:mainnet": "forge script script/deploy/10_AdminTransfer.s.sol --rpc-url $MAINNET_RPC_URL --private-key $PRIVATE_KEY --slow",
+    "VaultBytecode:deployment:deploy:tenderly": "forge script script/deploy/vault/DeployVaultBytecode.s.sol --rpc-url $TENDERLY_RPC_URL --private-key $PRIVATE_KEY --slow",
+    "VaultBytecode:deployment:deploy:mainnet": "forge script script/deploy/vault/DeployVaultBytecode.s.sol --rpc-url $MAINNET_RPC_URL --private-key $PRIVATE_KEY --slow",
+    "VaultFactory:deployment:deploy:anvil": "forge script script/deploy/vault/DeployVaultFactory.s.sol --rpc-url http://localhost:8545 --private-key $PRIVATE_KEY --slow",
+    "VaultFactory:deployment:deploy:tenderly": "forge script script/deploy/vault/DeployVaultFactory.s.sol --rpc-url $TENDERLY_RPC_URL --private-key $PRIVATE_KEY --slow",
+    "VaultFactory:deployment:deploy:mainnet": "forge script script/deploy/vault/DeployVaultFactory.s.sol --rpc-url $MAINNET_RPC_URL --private-key $PRIVATE_KEY --slow",
+    "Vault:deployment:deploy:tenderly": "forge script script/deploy/vault/DeployVault.s.sol --rpc-url $TENDERLY_RPC_URL --private-key $PRIVATE_KEY --slow",
+    "Vault:deployment:deploy:mainnet": "forge script script/deploy/vault/DeployVault.s.sol --rpc-url $MAINNET_RPC_URL --private-key $PRIVATE_KEY --slow"
   },
   "dependencies": {
     "date-fns": "^2.30.0",

--- a/script/Base.s.sol
+++ b/script/Base.s.sol
@@ -6,6 +6,7 @@ import { ValidateInterface } from "./ValidateInterface.s.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 
 import { Script, stdJson } from "forge-std/Script.sol";
+import { console2 } from "forge-std/console2.sol";
 
 abstract contract BaseScript is Script, ValidateInterface {
     using stdJson for string;
@@ -41,6 +42,8 @@ abstract contract BaseScript is Script, ValidateInterface {
             mnemonic = vm.envOr({ name: "MNEMONIC", defaultValue: TEST_MNEMONIC });
             (broadcaster,) = deriveRememberKey({ mnemonic: mnemonic, index: 0 });
         }
+
+        console2.log("broadcaster", broadcaster);
     }
 
     modifier broadcast() {

--- a/script/ValidateInterface.s.sol
+++ b/script/ValidateInterface.s.sol
@@ -19,6 +19,11 @@ abstract contract ValidateInterface {
     function _validateInterfaceIonPool(IonPool ionPool) internal view {
         require(address(ionPool).code.length > 0, "ionPool address must have code");
         ionPool.balanceOf(address(this));
+        ionPool.totalSupply();
+        ionPool.GEM_JOIN_ROLE();
+        ionPool.LIQUIDATOR_ROLE();
+        ionPool.PAUSE_ROLE();
+        ionPool.calculateRewardAndDebtDistribution();
     }
 
     function _validateInterface(IERC20 ilkAddress) internal view {

--- a/script/deploy/vault/DeployVault.s.sol
+++ b/script/deploy/vault/DeployVault.s.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import { Vault } from "./../../../src/vault/Vault.sol";
+import { VaultFactory } from "./../../../src/vault/VaultFactory.sol";
+import { IIonPool } from "./../../../src/interfaces/IIonPool.sol";
+import { IonPool } from "./../../../src/IonPool.sol";
+import { IERC20 } from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+
+import { BaseScript } from "./../../Base.s.sol";
+
+import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import { stdJson as StdJson } from "forge-std/StdJson.sol";
+
+VaultFactory constant factory = VaultFactory(address(0));
+/**
+ * Always use the factory to deploy a vault.
+ */
+
+contract DeployVault is BaseScript {
+    using EnumerableSet for EnumerableSet.AddressSet;
+    using StdJson for string;
+    using SafeCast for uint256;
+
+    string configPath = "./deployment-config/vault/DeployVault.json";
+    string config = vm.readFile(configPath);
+
+    VaultFactory factory = VaultFactory(config.readAddress(".factory"));
+
+    address baseAsset = config.readAddress(".baseAsset");
+
+    address feeRecipient = config.readAddress(".feeRecipient");
+    uint256 feePercentage = config.readUint(".feePercentage");
+
+    string name = config.readString(".name");
+    string symbol = config.readString(".symbol");
+
+    uint48 initialDelay = config.readUint(".initialDelay").toUint48();
+    address initialDefaultAdmin = config.readAddress(".initialDefaultAdmin");
+
+    bytes32 salt = config.readBytes32(".salt");
+
+    uint256 initialDeposit = config.readUint(".initialDeposit");
+
+    address[] marketsToAdd = config.readAddressArray(".marketsToAdd");
+    uint256[] allocationCaps = config.readUintArray(".allocationCaps");
+    address[] supplyQueue = config.readAddressArray(".supplyQueue");
+    address[] withdrawQueue = config.readAddressArray(".withdrawQueue");
+
+    IIonPool public constant IDLE = IIonPool(address(uint160(uint256(keccak256("IDLE_ASSET_HOLDINGS")))));
+
+    EnumerableSet.AddressSet marketsCheck;
+
+    /**
+     * Validate that the salt is msg.sender protected.
+     */
+    function _validateSalt(bytes32 salt) internal {
+        if (address(bytes20(salt)) != broadcaster) {
+            revert("Invalid Salt");
+        }
+    }
+
+    /**
+     * No duplicates. No zero addresses. IonPool Interface.
+     */
+    function _validateIonPoolArray(address[] memory ionPools) internal returns (IIonPool[] memory typedIonPools) {
+        typedIonPools = new IIonPool[](ionPools.length);
+
+        for (uint8 i = 0; i < ionPools.length; i++) {
+            address pool = ionPools[i];
+
+            require(pool != address(0), "zero address");
+
+            marketsCheck.add(pool);
+
+            // If not the IDLE address, then validate the IonPool interface.
+            if (pool != address(IDLE)) {
+                _validateInterfaceIonPool(IonPool(pool));
+            }
+
+            // Check for duplicates in this array
+            if (i != ionPools.length - 1) {
+                for (uint8 j = i + 1; j < ionPools.length; j++) {
+                    require(ionPools[i] != ionPools[j], "duplicate");
+                }
+            }
+
+            typedIonPools[i] = IIonPool(pool);
+        }
+    }
+
+    function run() public broadcast returns (Vault vault) {
+        require(baseAsset != address(0), "baseAsset");
+
+        require(feeRecipient != address(0), "feeRecipient");
+        require(feePercentage <= 0.2e27, "feePercentage");
+
+        // require(initialDelay != 0, "initialDelay");
+        require(initialDefaultAdmin != address(0), "initialDefaultAdmin");
+
+        require(initialDeposit >= 1e3, "initialDeposit");
+        require(IERC20(baseAsset).balanceOf(broadcaster) >= initialDeposit, "sender balance");
+        // require(IERC20(baseAsset).allowance(broadcaster, address(factory)) >= initialDeposit, "sender allowance");
+
+        if (IERC20(baseAsset).allowance(broadcaster, address(factory)) < initialDeposit) {
+            IERC20(baseAsset).approve(address(factory), 1e9);
+        }
+
+        // The length of all the arrays must be the same.
+        require(marketsToAdd.length > 0);
+        require(allocationCaps.length > 0);
+        require(supplyQueue.length > 0);
+        require(withdrawQueue.length > 0);
+
+        uint256 marketsLength = marketsToAdd.length;
+
+        require(marketsToAdd.length == marketsLength, "array length");
+        require(allocationCaps.length == marketsLength, "array length");
+        require(supplyQueue.length == marketsLength, "array length");
+
+        _validateSalt(salt);
+
+        IIonPool[] memory typedMarketsToAdd = _validateIonPoolArray(marketsToAdd);
+        IIonPool[] memory typedSupplyQueue = _validateIonPoolArray(supplyQueue);
+        IIonPool[] memory typedWithdrawQueue = _validateIonPoolArray(withdrawQueue);
+
+        // If the length of the `uniqueMarketsCheck` set is greater than 4, that
+        // means not all of the IonPool arrays had the same set of markets.
+        // `_validateIonPoolArray` must be called before this.
+        require(marketsToAdd.length == marketsCheck.length(), "markets not consistent");
+
+        Vault.MarketsArgs memory marketsArgs = Vault.MarketsArgs({
+            marketsToAdd: typedMarketsToAdd,
+            allocationCaps: allocationCaps,
+            newSupplyQueue: typedSupplyQueue,
+            newWithdrawQueue: typedWithdrawQueue
+        });
+
+        vault = factory.createVault(
+            IERC20(baseAsset),
+            feeRecipient,
+            feePercentage,
+            name,
+            symbol,
+            initialDelay,
+            initialDefaultAdmin,
+            salt,
+            marketsArgs,
+            initialDeposit
+        );
+
+        require(vault.feeRecipient() == feeRecipient, "feeRecipient");
+        require(vault.feePercentage() == feePercentage, "feePercentage");
+        require(vault.defaultAdminDelay() == initialDelay, "initialDelay");
+        require(vault.defaultAdmin() == initialDefaultAdmin, "initialDefaultAdmin");
+        for (uint8 i = 0; i < marketsLength; i++) {
+            require(vault.supplyQueue(i) == typedSupplyQueue[i], "supplyQueue");
+            require(vault.withdrawQueue(i) == typedWithdrawQueue[i], "withdrawQueue");
+        }
+        require(vault.supportedMarketsLength() == marketsLength, "supportedMarkets");
+    }
+}

--- a/script/deploy/vault/DeployVaultBytecode.s.sol
+++ b/script/deploy/vault/DeployVaultBytecode.s.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import { VaultBytecode } from "./../../../src/vault/VaultBytecode.sol";
+import { CREATEX } from "./../../../src/Constants.sol";
+
+import { DeployScript } from "./../../Deploy.s.sol";
+
+bytes32 constant SALT = 0xbcde1e1dd0bdb803514d8e000000000000000000000000000000000000000000;
+
+contract DeployVaultBytecode is DeployScript {
+    function run() public broadcast returns (VaultBytecode vaultBytecode) {
+        bytes memory initCode = type(VaultBytecode).creationCode;
+
+        require(initCode.length > 0, "initCode");
+        require(SALT != bytes32(0), "salt");
+
+        vaultBytecode = VaultBytecode(CREATEX.deployCreate3(SALT, initCode));
+    }
+}

--- a/script/deploy/vault/DeployVaultFactory.s.sol
+++ b/script/deploy/vault/DeployVaultFactory.s.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import { VaultFactory } from "./../../../src/vault/VaultFactory.sol";
+import { CREATEX } from "./../../../src/Constants.sol";
+
+import { DeployScript } from "./../../Deploy.s.sol";
+
+// deploys to 0x0000000000d7dc416dfe993b0e3dd53ba3e27fc8
+bytes32 constant SALT = 0x2f428c0d9f1d9e00034c85000000000000000000000000000000000000000000;
+
+contract DeployVaultFactory is DeployScript {
+    function run() public broadcast returns (VaultFactory vaultFactory) {
+        bytes memory initCode = type(VaultFactory).creationCode;
+
+        require(initCode.length > 0, "initCode");
+        require(SALT != bytes32(0), "salt");
+
+        vaultFactory = VaultFactory(CREATEX.deployCreate3(SALT, initCode));
+    }
+}

--- a/src/vault/Vault.sol
+++ b/src/vault/Vault.sol
@@ -114,6 +114,9 @@ contract Vault is ERC4626, Multicall, AccessControlDefaultAdminRules, Reentrancy
     {
         BASE_ASSET = _baseAsset;
 
+        if (_feePercentage > RAY) revert InvalidFeePercentage();
+        if (_feeRecipient == address(0)) revert InvalidFeeRecipient();
+
         feePercentage = _feePercentage;
         feeRecipient = _feeRecipient;
 

--- a/src/vault/VaultBytecode.sol
+++ b/src/vault/VaultBytecode.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.21;
+
+import { Vault } from "./Vault.sol";
+import { IERC20 } from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+
+/**
+ * @title VaultBytecode
+ * @author Molecular Labs
+ * @notice The sole job of this contract is to deploy the embedded `Vault`
+ * contract's bytecode with the constructor args. `VaultFactory` handles rest of
+ * the verification and post-deployment logic.
+ */
+contract VaultBytecode {
+    error OnlyFactory();
+
+    address constant VAULT_FACTORY = 0x0000000000D7DC416dFe993b0E3dd53BA3E27Fc8;
+
+    /**
+     * @notice Deploys the embedded `Vault` bytecode with the given constructor
+     * args. Only the `VaultFactory` contract can call this function.
+     * @dev This contract was separated from `VaultFactory` to reduce the
+     * codesize of the factory contract.
+     * @param baseAsset The asset that is being lent out to IonPools.
+     * @param feeRecipient Address that receives the accrued manager fees.
+     * @param feePercentage Fee percentage to be set.
+     * @param name Name of the vault token.
+     * @param symbol Symbol of the vault token.
+     * @param initialDelay The initial delay for default admin transfers.
+     * @param initialDefaultAdmin The initial default admin for the vault.
+     * @param salt The salt used for CREATE2 deployment. The first 20 bytes must
+     * be the msg.sender.
+     * @param marketsArgs Arguments for the markets to be added to the vault.
+     */
+    function deploy(
+        IERC20 baseAsset,
+        address feeRecipient,
+        uint256 feePercentage,
+        string memory name,
+        string memory symbol,
+        uint48 initialDelay,
+        address initialDefaultAdmin,
+        bytes32 salt,
+        Vault.MarketsArgs memory marketsArgs
+    )
+        external
+        returns (Vault vault)
+    {
+        if (msg.sender != VAULT_FACTORY) revert OnlyFactory();
+
+        vault = new Vault{ salt: salt }(
+            baseAsset, feeRecipient, feePercentage, name, symbol, initialDelay, initialDefaultAdmin, marketsArgs
+        );
+    }
+}

--- a/src/vault/VaultFactory.sol
+++ b/src/vault/VaultFactory.sol
@@ -12,8 +12,8 @@ import { SafeERC20 } from "openzeppelin-contracts/contracts/token/ERC20/utils/Sa
  */
 contract VaultFactory {
     using SafeERC20 for IERC20;
-    
-    // --- Errors --- 
+
+    // --- Errors ---
     error SaltMustBeginWithMsgSender();
 
     // --- Events ---
@@ -28,11 +28,11 @@ contract VaultFactory {
         address indexed initialDefaultAdmin
     );
 
-    // --- Modifier --- 
+    // --- Modifier ---
     /**
      * @dev Guarantees msg.sender protection for salts. If another caller
      * frontruns a deployment transaction, the salt cannot be stolen.
-     * Taken from 0age's `Create2Factory`. 
+     * Taken from 0age's `Create2Factory`.
      * https://github.com/0age/Pr000xy/blob/master/contracts/Create2Factory.sol
      * @param salt The salt used for CREATE2 deployment. The first 20 bytes must
      * be the msg.sender.

--- a/src/vault/VaultFactory.sol
+++ b/src/vault/VaultFactory.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.21;
 
+import { VaultBytecode } from "./VaultBytecode.sol";
 import { Vault } from "./Vault.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
 import { SafeERC20 } from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -14,6 +15,7 @@ contract VaultFactory {
     using SafeERC20 for IERC20;
 
     // --- Errors ---
+
     error SaltMustBeginWithMsgSender();
 
     // --- Events ---
@@ -28,7 +30,10 @@ contract VaultFactory {
         address indexed initialDefaultAdmin
     );
 
+    VaultBytecode constant BYTECODE_DEPLOYER = VaultBytecode(0x0000000000382a154e4A696A8C895b4292fA3D82);
+
     // --- Modifier ---
+
     /**
      * @dev Guarantees msg.sender protection for salts. If another caller
      * frontruns a deployment transaction, the salt cannot be stolen.
@@ -82,8 +87,8 @@ contract VaultFactory {
         containsCaller(salt)
         returns (Vault vault)
     {
-        vault = new Vault{ salt: salt }(
-            baseAsset, feeRecipient, feePercentage, name, symbol, initialDelay, initialDefaultAdmin, marketsArgs
+        vault = BYTECODE_DEPLOYER.deploy(
+            baseAsset, feeRecipient, feePercentage, name, symbol, initialDelay, initialDefaultAdmin, salt, marketsArgs
         );
 
         baseAsset.safeTransferFrom(msg.sender, address(this), initialDeposit);

--- a/test/fork/concrete/vault/Vault.t.sol
+++ b/test/fork/concrete/vault/Vault.t.sol
@@ -30,7 +30,7 @@ contract Vault_ForkTest is VaultForkBase {
 
         // vault
         assertEq(resultingSharesMinted, totalSupplyAfterDeposit - totalSupply, "vault total supply after deposit");
-        assertApproxEqAbs(maxDeposit, totalAssetsAfterDeposit - totalAssets, 3, "vault total assets after deposit"); // 1
+        assertApproxEqAbs(maxDeposit, totalAssetsAfterDeposit - totalAssets, 4, "vault total assets after deposit"); // 1
             // wei error per market
 
         uint256 withdrawAmt = vault.maxWithdraw(address(this));
@@ -49,7 +49,9 @@ contract Vault_ForkTest is VaultForkBase {
         assertEq(
             resultingSharesRedeemed, totalSupplyAfterDeposit - totalSupplyAfterWithdraw, "total supply after withdraw"
         );
-        assertEq(withdrawAmt, totalAssetsAfterDeposit - totalAssetsAfterWithdraw, "total assets after withdraw");
+        assertApproxEqAbs(
+            withdrawAmt, totalAssetsAfterDeposit - totalAssetsAfterWithdraw, 3, "total assets after withdraw"
+        );
     }
 
     function test_Deposit_MaxMint_MaxRedeem() public {
@@ -77,7 +79,7 @@ contract Vault_ForkTest is VaultForkBase {
         // vault
         assertEq(maxMint, totalSupplyAfterMint - totalSupply, "vault total supply after deposit");
         assertApproxEqAbs(
-            resultingAssetsDeposited, totalAssetsAfterMint - totalAssets, 3, "vault total assets after deposit"
+            resultingAssetsDeposited, totalAssetsAfterMint - totalAssets, 4, "vault total assets after deposit"
         ); // 1 wei error per market
 
         uint256 prevShares = vault.balanceOf(address(this));

--- a/test/fork/concrete/vault/VaultFactory.t.sol
+++ b/test/fork/concrete/vault/VaultFactory.t.sol
@@ -24,12 +24,6 @@ contract VaultFactoryTest is VaultSharedSetup {
     IIonPool[] internal newSupplyQueue;
     IIonPool[] internal newWithdrawQueue;
 
-    function _getSalt(address caller, bytes memory str) public returns (bytes32 salt) {
-        bytes32 keccak = keccak256(str);
-        salt = bytes32(abi.encodePacked(caller, keccak)); 
-        require(address(bytes20(salt)) == caller, 'invalid salt creation');
-    }
-
     function setUp() public override {
         super.setUp();
 
@@ -61,7 +55,7 @@ contract VaultFactoryTest is VaultSharedSetup {
     }
 
     function test_CreateVault_Basic() public {
-        bytes32 salt = _getSalt(address(this), "random salt"); 
+        bytes32 salt = _getSalt(address(this), "random salt");
 
         Vault vault = factory.createVault(
             baseAsset,
@@ -109,7 +103,7 @@ contract VaultFactoryTest is VaultSharedSetup {
     }
 
     function test_CreateVault_SameBytecodeDifferentSalt() public {
-        bytes32 salt = _getSalt(address(this), "random salt"); 
+        bytes32 salt = _getSalt(address(this), "random salt");
 
         Vault vault = factory.createVault(
             baseAsset,
@@ -127,7 +121,7 @@ contract VaultFactoryTest is VaultSharedSetup {
         setERC20Balance(address(BASE_ASSET), address(this), MIN_INITIAL_DEPOSIT);
         BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
 
-        bytes32 salt2 = _getSalt(address(this), "second random salt"); 
+        bytes32 salt2 = _getSalt(address(this), "second random salt");
         Vault vault2 = factory.createVault(
             baseAsset,
             feeRecipient,
@@ -151,7 +145,7 @@ contract VaultFactoryTest is VaultSharedSetup {
     }
 
     function test_Revert_CreateVault_SameSaltTwice() public {
-        bytes32 salt = _getSalt(address(this), "random salt"); 
+        bytes32 salt = _getSalt(address(this), "random salt");
 
         Vault vault = factory.createVault(
             baseAsset,
@@ -180,7 +174,7 @@ contract VaultFactoryTest is VaultSharedSetup {
             MIN_INITIAL_DEPOSIT
         );
     }
-    
+
     function test_Revert_SaltMustBeginWithMsgSender() public {
         bytes32 salt = _getSalt(address(1), "random salt");
         require(address(this) != address(1));
@@ -197,7 +191,7 @@ contract VaultFactoryTest is VaultSharedSetup {
             salt,
             marketsArgs,
             MIN_INITIAL_DEPOSIT
-        ); 
+        );
     }
 
     /**
@@ -205,10 +199,10 @@ contract VaultFactoryTest is VaultSharedSetup {
      * different, it should deploy to different addresses.
      */
     function test_Revert_SaltBeginsWithMsgSenderButDiffEnding() public {
-        bytes32 salt1 = _getSalt(address(this), "first random salt"); 
-        bytes32 salt2 = _getSalt(address(this), "second random salt"); 
+        bytes32 salt1 = _getSalt(address(this), "first random salt");
+        bytes32 salt2 = _getSalt(address(this), "second random salt");
 
-        require(salt1 != salt2, 'salt must be different');
+        require(salt1 != salt2, "salt must be different");
 
         deal(address(BASE_ASSET), address(this), MIN_INITIAL_DEPOSIT);
         BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
@@ -238,13 +232,13 @@ contract VaultFactoryTest is VaultSharedSetup {
             salt2,
             marketsArgs,
             MIN_INITIAL_DEPOSIT
-        );  
+        );
 
         assertTrue(address(vault1) != address(vault2), "deployment addresses must be different");
     }
 
     function test_CreateVault_SameSaltDifferentBytecode() public {
-        bytes32 salt = _getSalt(address(this), "random salt"); 
+        bytes32 salt = _getSalt(address(this), "random salt");
 
         Vault vault = factory.createVault(
             BASE_ASSET,
@@ -316,7 +310,7 @@ contract VaultFactoryTest is VaultSharedSetup {
         address deployer = newAddress("DEPLOYER");
         // deploy using the factory which enforces minimum deposit of 1e9 assets
         // and the 1e3 shares burn.
-        bytes32 salt = _getSalt(deployer, "random salt"); 
+        bytes32 salt = _getSalt(deployer, "random salt");
 
         setERC20Balance(address(BASE_ASSET), deployer, MIN_INITIAL_DEPOSIT);
 
@@ -460,7 +454,7 @@ contract VaultFactoryTest is VaultSharedSetup {
             marketsArgs,
             MIN_INITIAL_DEPOSIT
         );
-        vm.stopPrank(); 
+        vm.stopPrank();
     }
 
     /**
@@ -474,8 +468,8 @@ contract VaultFactoryTest is VaultSharedSetup {
         deal(address(BASE_ASSET), deployer, MIN_INITIAL_DEPOSIT);
         deal(address(BASE_ASSET), attacker, MIN_INITIAL_DEPOSIT);
 
-        bytes32 deployerSalt = _getSalt(deployer, "random"); 
-        bytes32 attackerSalt = _getSalt(attacker, "random"); 
+        bytes32 deployerSalt = _getSalt(deployer, "random");
+        bytes32 attackerSalt = _getSalt(attacker, "random");
 
         vm.startPrank(deployer);
         BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
@@ -507,7 +501,7 @@ contract VaultFactoryTest is VaultSharedSetup {
             marketsArgs,
             MIN_INITIAL_DEPOSIT
         );
-        vm.stopPrank(); 
+        vm.stopPrank();
 
         assertTrue(address(deployerVault) != address(attackerVault), "different deployment address");
     }

--- a/test/fork/concrete/vault/VaultFactory.t.sol
+++ b/test/fork/concrete/vault/VaultFactory.t.sol
@@ -24,6 +24,12 @@ contract VaultFactoryTest is VaultSharedSetup {
     IIonPool[] internal newSupplyQueue;
     IIonPool[] internal newWithdrawQueue;
 
+    function _getSalt(address caller, bytes memory str) public returns (bytes32 salt) {
+        bytes32 keccak = keccak256(str);
+        salt = bytes32(abi.encodePacked(caller, keccak)); 
+        require(address(bytes20(salt)) == caller, 'invalid salt creation');
+    }
+
     function setUp() public override {
         super.setUp();
 
@@ -54,8 +60,9 @@ contract VaultFactoryTest is VaultSharedSetup {
         BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
     }
 
-    function test_CreateVault() public {
-        bytes32 salt = keccak256("random salt");
+    function test_CreateVault_Basic() public {
+        bytes32 salt = _getSalt(address(this), "random salt"); 
+
         Vault vault = factory.createVault(
             baseAsset,
             feeRecipient,
@@ -101,8 +108,9 @@ contract VaultFactoryTest is VaultSharedSetup {
         assertEq(vault.balanceOf(address(this)), MIN_INITIAL_DEPOSIT - 1e3, "deployer gets 1e3 less shares");
     }
 
-    function test_CreateVault_Twice() public {
-        bytes32 salt = keccak256("first random salt");
+    function test_CreateVault_SameBytecodeDifferentSalt() public {
+        bytes32 salt = _getSalt(address(this), "random salt"); 
+
         Vault vault = factory.createVault(
             baseAsset,
             feeRecipient,
@@ -119,7 +127,7 @@ contract VaultFactoryTest is VaultSharedSetup {
         setERC20Balance(address(BASE_ASSET), address(this), MIN_INITIAL_DEPOSIT);
         BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
 
-        bytes32 salt2 = keccak256("second random salt");
+        bytes32 salt2 = _getSalt(address(this), "second random salt"); 
         Vault vault2 = factory.createVault(
             baseAsset,
             feeRecipient,
@@ -143,7 +151,8 @@ contract VaultFactoryTest is VaultSharedSetup {
     }
 
     function test_Revert_CreateVault_SameSaltTwice() public {
-        bytes32 salt = keccak256("random salt");
+        bytes32 salt = _getSalt(address(this), "random salt"); 
+
         Vault vault = factory.createVault(
             baseAsset,
             feeRecipient,
@@ -171,9 +180,71 @@ contract VaultFactoryTest is VaultSharedSetup {
             MIN_INITIAL_DEPOSIT
         );
     }
+    
+    function test_Revert_SaltMustBeginWithMsgSender() public {
+        bytes32 salt = _getSalt(address(1), "random salt");
+        require(address(this) != address(1));
+
+        vm.expectRevert(VaultFactory.SaltMustBeginWithMsgSender.selector);
+        Vault vault = factory.createVault(
+            baseAsset,
+            feeRecipient,
+            feePercentage,
+            name,
+            symbol,
+            INITIAL_DELAY,
+            VAULT_ADMIN,
+            salt,
+            marketsArgs,
+            MIN_INITIAL_DEPOSIT
+        ); 
+    }
+
+    /**
+     * If the salt begins with the same sender, but the ending bytes are
+     * different, it should deploy to different addresses.
+     */
+    function test_Revert_SaltBeginsWithMsgSenderButDiffEnding() public {
+        bytes32 salt1 = _getSalt(address(this), "first random salt"); 
+        bytes32 salt2 = _getSalt(address(this), "second random salt"); 
+
+        require(salt1 != salt2, 'salt must be different');
+
+        deal(address(BASE_ASSET), address(this), MIN_INITIAL_DEPOSIT);
+        BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
+        Vault vault1 = factory.createVault(
+            baseAsset,
+            feeRecipient,
+            feePercentage,
+            name,
+            symbol,
+            INITIAL_DELAY,
+            VAULT_ADMIN,
+            salt1,
+            marketsArgs,
+            MIN_INITIAL_DEPOSIT
+        );
+
+        deal(address(BASE_ASSET), address(this), MIN_INITIAL_DEPOSIT);
+        BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
+        Vault vault2 = factory.createVault(
+            baseAsset,
+            feeRecipient,
+            feePercentage,
+            name,
+            symbol,
+            INITIAL_DELAY,
+            VAULT_ADMIN,
+            salt2,
+            marketsArgs,
+            MIN_INITIAL_DEPOSIT
+        );  
+
+        assertTrue(address(vault1) != address(vault2), "deployment addresses must be different");
+    }
 
     function test_CreateVault_SameSaltDifferentBytecode() public {
-        bytes32 salt = keccak256("random salt");
+        bytes32 salt = _getSalt(address(this), "random salt"); 
 
         Vault vault = factory.createVault(
             BASE_ASSET,
@@ -245,7 +316,7 @@ contract VaultFactoryTest is VaultSharedSetup {
         address deployer = newAddress("DEPLOYER");
         // deploy using the factory which enforces minimum deposit of 1e9 assets
         // and the 1e3 shares burn.
-        bytes32 salt = keccak256("random salt");
+        bytes32 salt = _getSalt(deployer, "random salt"); 
 
         setERC20Balance(address(BASE_ASSET), deployer, MIN_INITIAL_DEPOSIT);
 
@@ -347,5 +418,97 @@ contract VaultFactoryTest is VaultSharedSetup {
         assertLe(attackerGainFromAlice, lossFromDonation, "attack must not be profitable");
         assertLe(afterAssetBalance, initialAssetBalance, "attacker must not be profitable");
         assertLe(1e18, initialAssetBalance - afterAssetBalance, "attacker loss greater than amount griefed");
+    }
+
+    function test_Revert_Create2FrontrunSameConstructorArgDiffMsgSender() public {
+        address deployer = newAddress("DEPLOYER");
+        address attacker = newAddress("ATTACKER");
+
+        deal(address(BASE_ASSET), deployer, MIN_INITIAL_DEPOSIT);
+        deal(address(BASE_ASSET), attacker, MIN_INITIAL_DEPOSIT);
+
+        bytes32 deployerSalt = _getSalt(deployer, "random salt");
+
+        vm.startPrank(deployer);
+        BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
+        Vault deployerVault = factory.createVault(
+            baseAsset,
+            feeRecipient,
+            feePercentage,
+            name,
+            symbol,
+            INITIAL_DELAY,
+            VAULT_ADMIN,
+            deployerSalt,
+            marketsArgs,
+            MIN_INITIAL_DEPOSIT
+        );
+        vm.stopPrank();
+
+        vm.startPrank(attacker);
+        BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
+        vm.expectRevert(); // create collision
+        Vault attackerVault = factory.createVault(
+            baseAsset,
+            feeRecipient,
+            feePercentage,
+            name,
+            symbol,
+            INITIAL_DELAY,
+            VAULT_ADMIN,
+            deployerSalt,
+            marketsArgs,
+            MIN_INITIAL_DEPOSIT
+        );
+        vm.stopPrank(); 
+    }
+
+    /**
+     * Deployed with the same salt, but because the `feeRecipient` input address
+     * was changed, the attacker transaction deploys to a different address.
+     */
+    function test_Create2FrontrunDifferentConstructorArgsAndDifferentSalt() public {
+        address deployer = newAddress("DEPLOYER");
+        address attacker = newAddress("ATTACKER");
+
+        deal(address(BASE_ASSET), deployer, MIN_INITIAL_DEPOSIT);
+        deal(address(BASE_ASSET), attacker, MIN_INITIAL_DEPOSIT);
+
+        bytes32 deployerSalt = _getSalt(deployer, "random"); 
+        bytes32 attackerSalt = _getSalt(attacker, "random"); 
+
+        vm.startPrank(deployer);
+        BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
+        Vault deployerVault = factory.createVault(
+            baseAsset,
+            feeRecipient,
+            feePercentage,
+            name,
+            symbol,
+            INITIAL_DELAY,
+            VAULT_ADMIN,
+            deployerSalt,
+            marketsArgs,
+            MIN_INITIAL_DEPOSIT
+        );
+        vm.stopPrank();
+
+        vm.startPrank(attacker);
+        BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
+        Vault attackerVault = factory.createVault(
+            baseAsset,
+            newAddress("ATTACKER_FRONTRUN_FEE_RECIPIENT"),
+            feePercentage,
+            name,
+            symbol,
+            INITIAL_DELAY,
+            VAULT_ADMIN,
+            attackerSalt,
+            marketsArgs,
+            MIN_INITIAL_DEPOSIT
+        );
+        vm.stopPrank(); 
+
+        assertTrue(address(deployerVault) != address(attackerVault), "different deployment address");
     }
 }

--- a/test/fork/concrete/vault/VaultFactory.t.sol
+++ b/test/fork/concrete/vault/VaultFactory.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.21;
 
 import { Vault } from "./../../../../src/vault/Vault.sol";
+import { VaultBytecode } from "./../../../../src/vault/VaultBytecode.sol";
 import { VaultFactory } from "./../../../../src/vault/VaultFactory.sol";
 import { VaultSharedSetup } from "../../../helpers/VaultSharedSetup.sol";
 import { ERC20PresetMinterPauser } from "../../../helpers/ERC20PresetMinterPauser.sol";
@@ -11,8 +12,6 @@ import { IIonPool } from "./../../../../src/interfaces/IIonPool.sol";
 import { console2 } from "forge-std/console2.sol";
 
 contract VaultFactoryTest is VaultSharedSetup {
-    VaultFactory factory;
-
     address internal feeRecipient = address(2);
     uint256 internal feePercentage = 0.02e27;
     IERC20 internal baseAsset = BASE_ASSET;
@@ -25,9 +24,7 @@ contract VaultFactoryTest is VaultSharedSetup {
     IIonPool[] internal newWithdrawQueue;
 
     function setUp() public override {
-        super.setUp();
-
-        factory = new VaultFactory();
+        super.setUp(); // factory deployed in parent
 
         marketsToAdd.push(weEthIonPool);
         marketsToAdd.push(rsEthIonPool);

--- a/test/fork/fuzz/vault/Vault.t.sol
+++ b/test/fork/fuzz/vault/Vault.t.sol
@@ -30,7 +30,7 @@ contract Vault_ForkFuzzTest is VaultForkBase {
 
         // vault
         assertEq(resultingSharesMinted, totalSupplyAfterDeposit - totalSupply, "vault total supply after deposit");
-        assertApproxEqAbs(depositAmt, totalAssetsAfterDeposit - totalAssets, 3, "vault total assets after deposit"); // 1
+        assertApproxEqAbs(depositAmt, totalAssetsAfterDeposit - totalAssets, 4, "vault total assets after deposit"); // 1
             // wei error per market
 
         // tries to withdraw max
@@ -52,7 +52,7 @@ contract Vault_ForkFuzzTest is VaultForkBase {
             resultingSharesRedeemed, totalSupplyAfterDeposit - totalSupplyAfterWithdraw, "total supply after withdraw"
         );
         assertApproxEqAbs(
-            withdrawAmt, totalAssetsAfterDeposit - totalAssetsAfterWithdraw, 1, "total assets after withdraw"
+            withdrawAmt, totalAssetsAfterDeposit - totalAssetsAfterWithdraw, 4, "total assets after withdraw"
         );
     }
 
@@ -83,7 +83,7 @@ contract Vault_ForkFuzzTest is VaultForkBase {
         // vault
         assertEq(mintAmt, totalSupplyAfterMint - totalSupply, "vault total supply after deposit");
         assertApproxEqAbs(
-            resultingAssetsDeposited, totalAssetsAfterMint - totalAssets, 3, "vault total assets after deposit"
+            resultingAssetsDeposited, totalAssetsAfterMint - totalAssets, 4, "vault total assets after deposit"
         ); // 1 wei error per market
 
         uint256 prevShares = vault.balanceOf(address(this));
@@ -106,7 +106,7 @@ contract Vault_ForkFuzzTest is VaultForkBase {
         // vault
         assertEq(redeemAmt, totalSupplyAfterMint - totalSupplyAfterRedeem, "total supply after withdraw");
         assertApproxEqAbs(
-            expectedWithdrawAmt, totalAssetsAfterMint - totalAssetsAfterRedeem, 1, "total assets after withdraw"
+            expectedWithdrawAmt, totalAssetsAfterMint - totalAssetsAfterRedeem, 3, "total assets after withdraw"
         );
     }
 }

--- a/test/fork/fuzz/vault/Vault.t.sol
+++ b/test/fork/fuzz/vault/Vault.t.sol
@@ -1,24 +1,24 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
-import { Vault } from "./../../../../src/vault/Vault.sol";
-
 import { VaultForkBase } from "./../../../helpers/VaultForkSharedSetup.sol";
 
-contract Vault_ForkTest is VaultForkBase {
-    function test_Deposit_MaxDeposit_MaxWithdraw() public {
+contract Vault_ForkFuzzTest is VaultForkBase {
+    function test_Deposit_BelowMaxDeposit_Withdraw_BelowMaxWithdraw(uint256 assets) public {
         uint256 totalAssets = vault.totalAssets();
         uint256 totalSupply = vault.totalSupply();
 
         uint256 maxDeposit = vault.maxDeposit(NULL);
         require(maxDeposit > 0, "max deposit");
 
-        uint256 expectedSharesMinted = vault.previewDeposit(maxDeposit);
+        uint256 depositAmt = bound(assets, 0, maxDeposit);
 
-        deal(address(BASE_ASSET), address(this), maxDeposit);
-        BASE_ASSET.approve(address(vault), maxDeposit);
+        uint256 expectedSharesMinted = vault.previewDeposit(depositAmt);
 
-        uint256 resultingSharesMinted = vault.deposit(maxDeposit, address(this));
+        deal(address(BASE_ASSET), address(this), depositAmt);
+        BASE_ASSET.approve(address(vault), depositAmt);
+
+        uint256 resultingSharesMinted = vault.deposit(depositAmt, address(this));
 
         uint256 totalAssetsAfterDeposit = vault.totalAssets();
         uint256 totalSupplyAfterDeposit = vault.totalSupply();
@@ -30,10 +30,12 @@ contract Vault_ForkTest is VaultForkBase {
 
         // vault
         assertEq(resultingSharesMinted, totalSupplyAfterDeposit - totalSupply, "vault total supply after deposit");
-        assertApproxEqAbs(maxDeposit, totalAssetsAfterDeposit - totalAssets, 3, "vault total assets after deposit"); // 1
+        assertApproxEqAbs(depositAmt, totalAssetsAfterDeposit - totalAssets, 3, "vault total assets after deposit"); // 1
             // wei error per market
 
-        uint256 withdrawAmt = vault.maxWithdraw(address(this));
+        // tries to withdraw max
+        uint256 maxWithdraw = vault.maxWithdraw(address(this));
+        uint256 withdrawAmt = bound(assets, 0, maxWithdraw);
 
         uint256 expectedSharesRedeemed = vault.previewWithdraw(withdrawAmt);
         uint256 resultingSharesRedeemed = vault.withdraw(withdrawAmt, address(this), address(this));
@@ -49,22 +51,26 @@ contract Vault_ForkTest is VaultForkBase {
         assertEq(
             resultingSharesRedeemed, totalSupplyAfterDeposit - totalSupplyAfterWithdraw, "total supply after withdraw"
         );
-        assertEq(withdrawAmt, totalAssetsAfterDeposit - totalAssetsAfterWithdraw, "total assets after withdraw");
+        assertApproxEqAbs(
+            withdrawAmt, totalAssetsAfterDeposit - totalAssetsAfterWithdraw, 1, "total assets after withdraw"
+        );
     }
 
-    function test_Deposit_MaxMint_MaxRedeem() public {
+    function test_Mint_BelowMaxMint_Redeem_BelowMaxRedeem(uint256 assets) public {
         uint256 totalAssets = vault.totalAssets();
         uint256 totalSupply = vault.totalSupply();
 
         uint256 maxMint = vault.maxMint(NULL);
         require(maxMint > 0, "max mint");
 
-        uint256 expectedAssetsDeposited = vault.previewMint(maxMint);
+        uint256 mintAmt = bound(assets, 0, maxMint);
+
+        uint256 expectedAssetsDeposited = vault.previewMint(mintAmt);
 
         deal(address(BASE_ASSET), address(this), expectedAssetsDeposited);
         BASE_ASSET.approve(address(vault), expectedAssetsDeposited);
 
-        uint256 resultingAssetsDeposited = vault.mint(maxMint, address(this));
+        uint256 resultingAssetsDeposited = vault.mint(mintAmt, address(this));
 
         uint256 totalAssetsAfterMint = vault.totalAssets();
         uint256 totalSupplyAfterMint = vault.totalSupply();
@@ -72,17 +78,19 @@ contract Vault_ForkTest is VaultForkBase {
         // user
         assertEq(BASE_ASSET.balanceOf(address(this)), 0, "requested assets deposited");
         assertEq(resultingAssetsDeposited, expectedAssetsDeposited, "assets deposited");
-        assertEq(vault.balanceOf(address(this)), maxMint, "vault shares");
+        assertEq(vault.balanceOf(address(this)), mintAmt, "vault shares");
 
         // vault
-        assertEq(maxMint, totalSupplyAfterMint - totalSupply, "vault total supply after deposit");
+        assertEq(mintAmt, totalSupplyAfterMint - totalSupply, "vault total supply after deposit");
         assertApproxEqAbs(
             resultingAssetsDeposited, totalAssetsAfterMint - totalAssets, 3, "vault total assets after deposit"
         ); // 1 wei error per market
 
         uint256 prevShares = vault.balanceOf(address(this));
 
-        uint256 redeemAmt = vault.maxRedeem(address(this));
+        uint256 maxRedeem = vault.maxRedeem(address(this));
+        uint256 redeemAmt = bound(assets, 0, maxRedeem);
+
         uint256 expectedWithdrawAmt = vault.previewRedeem(redeemAmt);
         uint256 resultingWithdrawAmt = vault.redeem(redeemAmt, address(this), address(this));
 

--- a/test/helpers/VaultForkSharedSetup.sol
+++ b/test/helpers/VaultForkSharedSetup.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import { VaultFactory } from "./../../../../src/vault/VaultFactory.sol";
+import { Vault } from "./../../../../src/vault/Vault.sol";
+import { IIonPool } from "./../../../../src/interfaces/IIonPool.sol";
+import { IonLens } from "./../../../../src/periphery/IonLens.sol";
+import { WSTETH_ADDRESS } from "./../../../../src/Constants.sol";
+import { IERC20 } from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+import { EnumerableSet } from "openzeppelin-contracts/contracts/utils/structs/EnumerableSet.sol";
+
+import "forge-std/Test.sol";
+
+using EnumerableSet for EnumerableSet.AddressSet;
+
+contract VaultForkBase is Test {
+    IIonPool constant WEETH_IONPOOL = IIonPool(0x0000000000eaEbd95dAfcA37A39fd09745739b78);
+    IIonPool constant RSETH_IONPOOL = IIonPool(0x0000000000E33e35EE6052fae87bfcFac61b1da9);
+    IIonPool constant RSWETH_IONPOOL = IIonPool(0x00000000007C8105548f9d0eE081987378a6bE93);
+    IonLens constant LENS = IonLens(0xe89AF12af000C4f76a57A3aD16ef8277a727DC81);
+    bytes32 constant ION_ROLE = 0x5ab1a5ffb29c47d95dec8c5f9ad49a551754822b51a3359ed1c21e2be24beefa;
+
+    IERC20 constant BASE_ASSET = WSTETH_ADDRESS;
+
+    address FEE_RECIPIENT = address(1);
+
+    uint48 constant INITIAL_DELAY = 0;
+    uint256 constant MIN_INITIAL_DEPOSIT = 1e3;
+
+    address VAULT_ADMIN = 0x0000000000417626Ef34D62C4DC189b021603f2F;
+
+    IIonPool constant IDLE = IIonPool(address(uint160(uint256(keccak256("IDLE_ASSET_HOLDINGS")))));
+
+    address constant NULL = address(0);
+    uint256 constant DEFAULT_ALLO_CAO = type(uint128).max;
+
+    IIonPool[] markets;
+    IIonPool[] supplyQueue;
+    IIonPool[] withdrawQueue;
+
+    Vault.MarketsArgs marketsArgs;
+
+    uint256[] allocationCaps;
+
+    VaultFactory factory;
+    Vault vault;
+
+    uint256 internal forkBlock = 0;
+
+    function updateSupplyCap(IIonPool pool, uint256 cap) internal {
+        vm.startPrank(pool.defaultAdmin());
+        pool.updateSupplyCap(cap);
+        vm.stopPrank();
+        assertEq(LENS.supplyCap(pool), cap, "supply cap update");
+    }
+
+    function setUp() public virtual {
+        if (forkBlock == 0) vm.createSelectFork(vm.envString("MAINNET_ARCHIVE_RPC_URL"));
+        else vm.createSelectFork(vm.envString("MAINNET_ARCHIVE_RPC_URL"), forkBlock);
+
+        factory = new VaultFactory();
+
+        markets.push(IDLE);
+        markets.push(WEETH_IONPOOL);
+        markets.push(RSETH_IONPOOL);
+        markets.push(RSWETH_IONPOOL);
+
+        allocationCaps.push(DEFAULT_ALLO_CAO);
+        allocationCaps.push(DEFAULT_ALLO_CAO);
+        allocationCaps.push(DEFAULT_ALLO_CAO);
+        allocationCaps.push(DEFAULT_ALLO_CAO);
+
+        supplyQueue.push(WEETH_IONPOOL);
+        supplyQueue.push(RSETH_IONPOOL);
+        supplyQueue.push(RSWETH_IONPOOL);
+        supplyQueue.push(IDLE);
+
+        withdrawQueue.push(IDLE);
+        withdrawQueue.push(RSWETH_IONPOOL);
+        withdrawQueue.push(RSETH_IONPOOL);
+        withdrawQueue.push(WEETH_IONPOOL);
+
+        marketsArgs.marketsToAdd = markets;
+        marketsArgs.allocationCaps = allocationCaps;
+        marketsArgs.newSupplyQueue = supplyQueue;
+        marketsArgs.newWithdrawQueue = withdrawQueue;
+
+        uint256 feePercentage = 0.02e27;
+
+        bytes32 salt = bytes32(abi.encodePacked(address(this), keccak256("random salt")));
+
+        deal(address(BASE_ASSET), address(this), MIN_INITIAL_DEPOSIT);
+        BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
+        vault = factory.createVault(
+            BASE_ASSET,
+            FEE_RECIPIENT,
+            feePercentage,
+            "Ion Vault Token",
+            "IVT",
+            INITIAL_DELAY,
+            VAULT_ADMIN,
+            salt,
+            marketsArgs,
+            MIN_INITIAL_DEPOSIT
+        );
+
+        require(vault.supplyQueue(0) == WEETH_IONPOOL);
+        require(vault.supplyQueue(1) == RSETH_IONPOOL);
+        require(vault.supplyQueue(2) == RSWETH_IONPOOL);
+        require(vault.supplyQueue(3) == IDLE);
+    }
+}

--- a/test/helpers/VaultSharedSetup.sol
+++ b/test/helpers/VaultSharedSetup.sol
@@ -167,6 +167,12 @@ contract VaultSharedSetup is IonPoolSharedSetup {
         ionPool.grantRole(ionPool.GEM_JOIN_ROLE(), address(gemJoin));
     }
 
+    function _getSalt(address caller, bytes memory str) internal returns (bytes32 salt) {
+        bytes32 keccak = keccak256(str);
+        salt = bytes32(abi.encodePacked(caller, keccak));
+        require(address(bytes20(salt)) == caller, "invalid salt creation");
+    }
+
     function claimAfterDeposit(uint256 currShares, uint256 amount, uint256 supplyFactor) internal returns (uint256) {
         uint256 sharesMinted = amount.rayDivDown(supplyFactor);
         uint256 resultingShares = currShares + sharesMinted;

--- a/test/unit/concrete/vault/Vault.t.sol
+++ b/test/unit/concrete/vault/Vault.t.sol
@@ -24,6 +24,22 @@ contract VaultSetUpTest is VaultSharedSetup {
         super.setUp();
     }
 
+    function test_Revert_InvalidFeeRecipientInConstructor() public {
+        address feeRecipient = address(0);
+        vm.expectRevert(Vault.InvalidFeeRecipient.selector);
+        vault = new Vault(
+            BASE_ASSET, address(0), ZERO_FEES, "Ion Vault Token", "IVT", INITIAL_DELAY, VAULT_ADMIN, emptyMarketsArgs
+        );
+    }
+
+    function test_Revert_InvalidFeePercentageInConstructor() public {
+        uint256 feePerc = 1e27 + 1;
+        vm.expectRevert(Vault.InvalidFeePercentage.selector);
+        vault = new Vault(
+            BASE_ASSET, FEE_RECIPIENT, feePerc, "Ion Vault Token", "IVT", INITIAL_DELAY, VAULT_ADMIN, emptyMarketsArgs
+        );
+    }
+
     function test_AddSupportedMarketsSeparately() public {
         vault = new Vault(
             BASE_ASSET, FEE_RECIPIENT, ZERO_FEES, "Ion Vault Token", "IVT", INITIAL_DELAY, VAULT_ADMIN, emptyMarketsArgs

--- a/test/unit/fuzz/vault/Vault.t.sol
+++ b/test/unit/fuzz/vault/Vault.t.sol
@@ -952,7 +952,7 @@ contract VaultInflationAttack is VaultSharedSetup {
 
         // deploy using the factory which enforces minimum deposit of 1e9 assets
         // and the 1e3 shares burn.
-        bytes32 salt = keccak256("random salt");
+        bytes32 salt = _getSalt(deployer, "random salt");
 
         setERC20Balance(address(BASE_ASSET), deployer, MIN_INITIAL_DEPOSIT);
 

--- a/test/unit/fuzz/vault/Vault.t.sol
+++ b/test/unit/fuzz/vault/Vault.t.sol
@@ -250,7 +250,7 @@ contract VaultWithYieldAndFeeSharedSetup is VaultSharedSetup {
 contract VaultWithYieldAndFee_Fuzz_FeeAccrual is VaultWithYieldAndFeeSharedSetup {
     function testFuzz_AccruedFeeShares(uint256 initialDeposit, uint256 feePerc, uint256 daysAccrued) public {
         // fee percentage
-        feePerc = bound(feePerc, 0, RAY - 1);
+        feePerc = bound(feePerc, 0, RAY);
 
         vm.prank(OWNER);
         vault.updateFeePercentage(feePerc);

--- a/test/unit/fuzz/vault/Vault.t.sol
+++ b/test/unit/fuzz/vault/Vault.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.21;
 
 import { Vault } from "./../../../../src/vault/Vault.sol";
-import { VaultFactory } from "./../../../../src/vault/VaultFactory.sol";
 import { IIonPool } from "./../../../../src/interfaces/IIonPool.sol";
 import { IonPoolExposed } from "../../../helpers/IonPoolSharedSetup.sol";
 import { VaultSharedSetup } from "../../../helpers/VaultSharedSetup.sol";
@@ -955,8 +954,6 @@ contract VaultInflationAttack is VaultSharedSetup {
         bytes32 salt = _getSalt(deployer, "random salt");
 
         setERC20Balance(address(BASE_ASSET), deployer, MIN_INITIAL_DEPOSIT);
-
-        VaultFactory factory = new VaultFactory();
 
         vm.startPrank(deployer);
         BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);


### PR DESCRIPTION
### Vault Deployment
- `VaultFactory`
    - Adds `msg.sender` protection to the `CREATE2` salt.  
- `VaultBytecode`
    - Separated out of `VaultFactory` due to codesize limit with the embedded `Vault` bytecode.  
- `Vault`