### PR TITLE
[OZ] H-02

### DIFF
--- a/script/deploy/vault/DeployVault.s.sol
+++ b/script/deploy/vault/DeployVault.s.sol
@@ -41,8 +41,6 @@ contract DeployVault is BaseScript {
 
     bytes32 salt = config.readBytes32(".salt");
 
-    uint256 initialDeposit = config.readUint(".initialDeposit");
-
     address[] marketsToAdd = config.readAddressArray(".marketsToAdd");
     uint256[] allocationCaps = config.readUintArray(".allocationCaps");
     address[] supplyQueue = config.readAddressArray(".supplyQueue");
@@ -99,14 +97,6 @@ contract DeployVault is BaseScript {
         // require(initialDelay != 0, "initialDelay");
         require(initialDefaultAdmin != address(0), "initialDefaultAdmin");
 
-        require(initialDeposit >= 1e3, "initialDeposit");
-        require(IERC20(baseAsset).balanceOf(broadcaster) >= initialDeposit, "sender balance");
-        // require(IERC20(baseAsset).allowance(broadcaster, address(factory)) >= initialDeposit, "sender allowance");
-
-        if (IERC20(baseAsset).allowance(broadcaster, address(factory)) < initialDeposit) {
-            IERC20(baseAsset).approve(address(factory), 1e9);
-        }
-
         // The length of all the arrays must be the same.
         require(marketsToAdd.length > 0);
         require(allocationCaps.length > 0);
@@ -146,8 +136,7 @@ contract DeployVault is BaseScript {
             initialDelay,
             initialDefaultAdmin,
             salt,
-            marketsArgs,
-            initialDeposit
+            marketsArgs
         );
 
         require(vault.feeRecipient() == feeRecipient, "feeRecipient");

--- a/src/vault/Vault.sol
+++ b/src/vault/Vault.sol
@@ -120,7 +120,7 @@ contract Vault is ERC4626, Multicall, AccessControlDefaultAdminRules, Reentrancy
         feePercentage = _feePercentage;
         feeRecipient = _feeRecipient;
 
-        DECIMALS_OFFSET = uint8(_zeroFloorSub(uint256(18), IERC20Metadata(address(_baseAsset)).decimals()));
+        DECIMALS_OFFSET = 4;
 
         _addSupportedMarkets(
             marketsArgs.marketsToAdd,

--- a/src/vault/VaultFactory.sol
+++ b/src/vault/VaultFactory.sol
@@ -52,13 +52,7 @@ contract VaultFactory {
     // --- External ---
 
     /**
-     * @notice Deploys a new Ion Lending Vault. Transfers the `initialDeposit`
-     * amount of the base asset from the caller initiate the first deposit to
-     * the vault. The minimum `initialDeposit` is 1e3. If less, this call would
-     * underflow as it will always burn 1e3 shares of the total shares minted to
-     * defend against inflation attacks.
-     * @dev The 1e3 initial deposit amount was chosen to defend against
-     * inflation attacks, referencing the UniV2 LP token implementation.
+     * @notice Deploys a new Ion Lending Vault.
      * @param baseAsset The asset that is being lent out to IonPools.
      * @param feeRecipient Address that receives the accrued manager fees.
      * @param feePercentage Fee percentage to be set.
@@ -69,7 +63,6 @@ contract VaultFactory {
      * @param salt The salt used for CREATE2 deployment. The first 20 bytes must
      * be the msg.sender.
      * @param marketsArgs Arguments for the markets to be added to the vault.
-     * @param initialDeposit The initial deposit to be made to the vault.
      */
     function createVault(
         IERC20 baseAsset,
@@ -80,8 +73,7 @@ contract VaultFactory {
         uint48 initialDelay,
         address initialDefaultAdmin,
         bytes32 salt,
-        Vault.MarketsArgs memory marketsArgs,
-        uint256 initialDeposit
+        Vault.MarketsArgs memory marketsArgs
     )
         external
         containsCaller(salt)
@@ -90,14 +82,6 @@ contract VaultFactory {
         vault = BYTECODE_DEPLOYER.deploy(
             baseAsset, feeRecipient, feePercentage, name, symbol, initialDelay, initialDefaultAdmin, salt, marketsArgs
         );
-
-        baseAsset.safeTransferFrom(msg.sender, address(this), initialDeposit);
-        baseAsset.approve(address(vault), initialDeposit);
-        uint256 sharesMinted = vault.deposit(initialDeposit, address(this));
-
-        // The factory keeps 1e3 shares to reduce inflation attack vector.
-        // Effectively burns this amount of shares by locking it in the factory.
-        vault.transfer(msg.sender, sharesMinted - 1e3);
 
         emit CreateVault(address(vault), baseAsset, feeRecipient, feePercentage, name, symbol, initialDefaultAdmin);
     }

--- a/test/fork/concrete/vault/VaultFactory.t.sol
+++ b/test/fork/concrete/vault/VaultFactory.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.21;
 
 import { Vault } from "./../../../../src/vault/Vault.sol";
-import { VaultBytecode } from "./../../../../src/vault/VaultBytecode.sol";
 import { VaultFactory } from "./../../../../src/vault/VaultFactory.sol";
 import { VaultSharedSetup } from "../../../helpers/VaultSharedSetup.sol";
 import { ERC20PresetMinterPauser } from "../../../helpers/ERC20PresetMinterPauser.sol";
@@ -55,16 +54,7 @@ contract VaultFactoryTest is VaultSharedSetup {
         bytes32 salt = _getSalt(address(this), "random salt");
 
         Vault vault = factory.createVault(
-            baseAsset,
-            feeRecipient,
-            feePercentage,
-            name,
-            symbol,
-            INITIAL_DELAY,
-            VAULT_ADMIN,
-            salt,
-            marketsArgs,
-            MIN_INITIAL_DEPOSIT
+            baseAsset, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, salt, marketsArgs
         );
 
         address[] memory supportedMarkets = vault.getSupportedMarkets();
@@ -91,45 +81,23 @@ contract VaultFactoryTest is VaultSharedSetup {
         }
 
         // initial deposits
-        assertEq(BASE_ASSET.balanceOf(address(this)), 0, "initial deposit spent");
-        assertEq(vault.totalAssets(), MIN_INITIAL_DEPOSIT, "total assets");
-        assertEq(vault.totalSupply(), MIN_INITIAL_DEPOSIT, "total supply");
+        assertEq(vault.totalAssets(), 0, "total assets");
+        assertEq(vault.totalSupply(), 0, "total supply");
 
-        assertEq(vault.balanceOf(address(factory)), 1e3, "factory gets 1e3 shares");
-        assertEq(vault.balanceOf(address(this)), MIN_INITIAL_DEPOSIT - 1e3, "deployer gets 1e3 less shares");
+        assertEq(vault.balanceOf(address(factory)), 0, "factory starts with zero shares");
+        assertEq(vault.balanceOf(address(this)), 0, "deployer zero shares");
     }
 
     function test_CreateVault_SameBytecodeDifferentSalt() public {
         bytes32 salt = _getSalt(address(this), "random salt");
 
         Vault vault = factory.createVault(
-            baseAsset,
-            feeRecipient,
-            feePercentage,
-            name,
-            symbol,
-            INITIAL_DELAY,
-            VAULT_ADMIN,
-            salt,
-            marketsArgs,
-            MIN_INITIAL_DEPOSIT
+            baseAsset, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, salt, marketsArgs
         );
-
-        setERC20Balance(address(BASE_ASSET), address(this), MIN_INITIAL_DEPOSIT);
-        BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
 
         bytes32 salt2 = _getSalt(address(this), "second random salt");
         Vault vault2 = factory.createVault(
-            baseAsset,
-            feeRecipient,
-            feePercentage,
-            name,
-            symbol,
-            INITIAL_DELAY,
-            VAULT_ADMIN,
-            salt2,
-            marketsArgs,
-            MIN_INITIAL_DEPOSIT
+            baseAsset, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, salt2, marketsArgs
         );
 
         assertEq(VAULT_ADMIN, vault.defaultAdmin(), "default admin");
@@ -145,30 +113,12 @@ contract VaultFactoryTest is VaultSharedSetup {
         bytes32 salt = _getSalt(address(this), "random salt");
 
         Vault vault = factory.createVault(
-            baseAsset,
-            feeRecipient,
-            feePercentage,
-            name,
-            symbol,
-            INITIAL_DELAY,
-            VAULT_ADMIN,
-            salt,
-            marketsArgs,
-            MIN_INITIAL_DEPOSIT
+            baseAsset, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, salt, marketsArgs
         );
 
         vm.expectRevert();
         Vault vault2 = factory.createVault(
-            baseAsset,
-            feeRecipient,
-            feePercentage,
-            name,
-            symbol,
-            INITIAL_DELAY,
-            VAULT_ADMIN,
-            salt,
-            marketsArgs,
-            MIN_INITIAL_DEPOSIT
+            baseAsset, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, salt, marketsArgs
         );
     }
 
@@ -178,16 +128,7 @@ contract VaultFactoryTest is VaultSharedSetup {
 
         vm.expectRevert(VaultFactory.SaltMustBeginWithMsgSender.selector);
         Vault vault = factory.createVault(
-            baseAsset,
-            feeRecipient,
-            feePercentage,
-            name,
-            symbol,
-            INITIAL_DELAY,
-            VAULT_ADMIN,
-            salt,
-            marketsArgs,
-            MIN_INITIAL_DEPOSIT
+            baseAsset, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, salt, marketsArgs
         );
     }
 
@@ -201,34 +142,12 @@ contract VaultFactoryTest is VaultSharedSetup {
 
         require(salt1 != salt2, "salt must be different");
 
-        deal(address(BASE_ASSET), address(this), MIN_INITIAL_DEPOSIT);
-        BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
         Vault vault1 = factory.createVault(
-            baseAsset,
-            feeRecipient,
-            feePercentage,
-            name,
-            symbol,
-            INITIAL_DELAY,
-            VAULT_ADMIN,
-            salt1,
-            marketsArgs,
-            MIN_INITIAL_DEPOSIT
+            baseAsset, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, salt1, marketsArgs
         );
 
-        deal(address(BASE_ASSET), address(this), MIN_INITIAL_DEPOSIT);
-        BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
         Vault vault2 = factory.createVault(
-            baseAsset,
-            feeRecipient,
-            feePercentage,
-            name,
-            symbol,
-            INITIAL_DELAY,
-            VAULT_ADMIN,
-            salt2,
-            marketsArgs,
-            MIN_INITIAL_DEPOSIT
+            baseAsset, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, salt2, marketsArgs
         );
 
         assertTrue(address(vault1) != address(vault2), "deployment addresses must be different");
@@ -238,16 +157,7 @@ contract VaultFactoryTest is VaultSharedSetup {
         bytes32 salt = _getSalt(address(this), "random salt");
 
         Vault vault = factory.createVault(
-            BASE_ASSET,
-            feeRecipient,
-            feePercentage,
-            name,
-            symbol,
-            INITIAL_DELAY,
-            VAULT_ADMIN,
-            salt,
-            marketsArgs,
-            MIN_INITIAL_DEPOSIT
+            BASE_ASSET, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, salt, marketsArgs
         );
 
         // Deploy a vault with different base assets
@@ -263,20 +173,8 @@ contract VaultFactoryTest is VaultSharedSetup {
         marketsArgs.newSupplyQueue = markets;
         marketsArgs.newWithdrawQueue = markets;
 
-        setERC20Balance(address(diffBaseAsset), address(this), MIN_INITIAL_DEPOSIT);
-        diffBaseAsset.approve(address(factory), MIN_INITIAL_DEPOSIT);
-
         Vault vault2 = factory.createVault(
-            diffBaseAsset,
-            feeRecipient,
-            feePercentage,
-            name,
-            symbol,
-            INITIAL_DELAY,
-            VAULT_ADMIN,
-            salt,
-            marketsArgs,
-            MIN_INITIAL_DEPOSIT
+            diffBaseAsset, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, salt, marketsArgs
         );
 
         require(address(vault) != address(vault2), "different deployment address");
@@ -305,26 +203,13 @@ contract VaultFactoryTest is VaultSharedSetup {
         marketsArgs.newWithdrawQueue = markets;
 
         address deployer = newAddress("DEPLOYER");
-        // deploy using the factory which enforces minimum deposit of 1e9 assets
-        // and the 1e3 shares burn.
+
         bytes32 salt = _getSalt(deployer, "random salt");
 
-        setERC20Balance(address(BASE_ASSET), deployer, MIN_INITIAL_DEPOSIT);
-
         vm.startPrank(deployer);
-        BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
 
         Vault vault = factory.createVault(
-            BASE_ASSET,
-            feeRecipient,
-            feePercentage,
-            name,
-            symbol,
-            INITIAL_DELAY,
-            VAULT_ADMIN,
-            salt,
-            marketsArgs,
-            MIN_INITIAL_DEPOSIT
+            BASE_ASSET, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, salt, marketsArgs
         );
         vm.stopPrank();
 
@@ -335,7 +220,8 @@ contract VaultFactoryTest is VaultSharedSetup {
         updateAllocationCaps(vault, type(uint256).max, type(uint256).max, type(uint256).max);
 
         uint256 donationAmt = 10e18;
-        uint256 mintAmt = 10;
+        uint256 mintAmt = 10; // 10 shares * 1 / 10000
+        uint256 assetsFromMint = vault.previewMint(mintAmt);
 
         // fund attacker
         setERC20Balance(address(BASE_ASSET), address(this), donationAmt + mintAmt);
@@ -345,6 +231,7 @@ contract VaultFactoryTest is VaultSharedSetup {
         console2.log("attacker balance before :");
         console2.log("%e", initialAssetBalance);
 
+        console2.log("minting: ", mintAmt);
         vault.mint(mintAmt, address(this));
         uint256 attackerClaimAfterMint = vault.previewRedeem(vault.balanceOf(address(this)));
 
@@ -357,8 +244,8 @@ contract VaultFactoryTest is VaultSharedSetup {
         // donate to inflate exchange rate by increasing `totalAssets`
         IERC20(address(BASE_ASSET)).transfer(address(vault), donationAmt);
 
-        assertEq(donationAmt + mintAmt + 1e3, vault.totalAssets(), "total assets");
-        assertEq(mintAmt + 1e3, vault.totalSupply(), "minted shares");
+        assertEq(donationAmt + assetsFromMint, vault.totalAssets(), "total assets");
+        assertEq(mintAmt, vault.totalSupply(), "minted shares");
 
         // how much of this donation was captured by the virtual shares on the vault?
         uint256 attackerClaimAfterDonation = vault.previewRedeem(vault.balanceOf(address(this)));
@@ -415,41 +302,20 @@ contract VaultFactoryTest is VaultSharedSetup {
         address deployer = newAddress("DEPLOYER");
         address attacker = newAddress("ATTACKER");
 
-        deal(address(BASE_ASSET), deployer, MIN_INITIAL_DEPOSIT);
         deal(address(BASE_ASSET), attacker, MIN_INITIAL_DEPOSIT);
 
         bytes32 deployerSalt = _getSalt(deployer, "random salt");
 
         vm.startPrank(deployer);
-        BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
         Vault deployerVault = factory.createVault(
-            baseAsset,
-            feeRecipient,
-            feePercentage,
-            name,
-            symbol,
-            INITIAL_DELAY,
-            VAULT_ADMIN,
-            deployerSalt,
-            marketsArgs,
-            MIN_INITIAL_DEPOSIT
+            baseAsset, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, deployerSalt, marketsArgs
         );
         vm.stopPrank();
 
         vm.startPrank(attacker);
-        BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
         vm.expectRevert(); // create collision
         Vault attackerVault = factory.createVault(
-            baseAsset,
-            feeRecipient,
-            feePercentage,
-            name,
-            symbol,
-            INITIAL_DELAY,
-            VAULT_ADMIN,
-            deployerSalt,
-            marketsArgs,
-            MIN_INITIAL_DEPOSIT
+            baseAsset, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, deployerSalt, marketsArgs
         );
         vm.stopPrank();
     }
@@ -469,18 +335,8 @@ contract VaultFactoryTest is VaultSharedSetup {
         bytes32 attackerSalt = _getSalt(attacker, "random");
 
         vm.startPrank(deployer);
-        BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
         Vault deployerVault = factory.createVault(
-            baseAsset,
-            feeRecipient,
-            feePercentage,
-            name,
-            symbol,
-            INITIAL_DELAY,
-            VAULT_ADMIN,
-            deployerSalt,
-            marketsArgs,
-            MIN_INITIAL_DEPOSIT
+            baseAsset, feeRecipient, feePercentage, name, symbol, INITIAL_DELAY, VAULT_ADMIN, deployerSalt, marketsArgs
         );
         vm.stopPrank();
 
@@ -495,8 +351,7 @@ contract VaultFactoryTest is VaultSharedSetup {
             INITIAL_DELAY,
             VAULT_ADMIN,
             attackerSalt,
-            marketsArgs,
-            MIN_INITIAL_DEPOSIT
+            marketsArgs
         );
         vm.stopPrank();
 

--- a/test/helpers/VaultForkSharedSetup.sol
+++ b/test/helpers/VaultForkSharedSetup.sol
@@ -96,8 +96,6 @@ contract VaultForkBase is Test {
 
         bytes32 salt = bytes32(abi.encodePacked(address(this), keccak256("random salt")));
 
-        deal(address(BASE_ASSET), address(this), MIN_INITIAL_DEPOSIT);
-        BASE_ASSET.approve(address(factory), MIN_INITIAL_DEPOSIT);
         vault = factory.createVault(
             BASE_ASSET,
             FEE_RECIPIENT,
@@ -107,8 +105,7 @@ contract VaultForkBase is Test {
             INITIAL_DELAY,
             VAULT_ADMIN,
             salt,
-            marketsArgs,
-            MIN_INITIAL_DEPOSIT
+            marketsArgs
         );
 
         require(vault.supplyQueue(0) == WEETH_IONPOOL);

--- a/test/helpers/VaultSharedSetup.sol
+++ b/test/helpers/VaultSharedSetup.sol
@@ -317,4 +317,8 @@ contract VaultSharedSetup is IonPoolSharedSetup {
             z := mul(gt(x, y), sub(x, y))
         }
     }
+
+    function _convertTo18(uint256 amt) internal view returns (uint256) {
+        return amt / (10 ** (vault.decimals() - 18));
+    }
 }

--- a/test/unit/concrete/vault/Vault.t.sol
+++ b/test/unit/concrete/vault/Vault.t.sol
@@ -758,8 +758,8 @@ abstract contract VaultDeposit is VaultSharedSetup {
 
         vault.deposit(depositAmount, address(this));
 
-        assertEq(vault.totalSupply(), depositAmount, "vault shares total supply");
-        assertEq(vault.balanceOf(address(this)), depositAmount, "user vault shares balance");
+        assertEq(_convertTo18(vault.totalSupply()), depositAmount, "vault shares total supply");
+        assertEq(_convertTo18(vault.balanceOf(address(this))), depositAmount, "user vault shares balance");
         assertEq(BASE_ASSET.balanceOf(address(vault)), 0, "base asset balance should be zero");
         assertEq(
             weEthIonPool.balanceOf(address(vault)),
@@ -783,8 +783,8 @@ abstract contract VaultDeposit is VaultSharedSetup {
         // 3e18 gets spread out equally amongst the three pools
         vault.deposit(depositAmount, address(this));
 
-        assertEq(vault.totalSupply(), depositAmount, "vault shares total supply");
-        assertEq(vault.balanceOf(address(this)), depositAmount, "user vault shares balance");
+        assertEq(_convertTo18(vault.totalSupply()), depositAmount, "vault shares total supply");
+        assertEq(_convertTo18(vault.balanceOf(address(this))), depositAmount, "user vault shares balance");
         assertEq(BASE_ASSET.balanceOf(address(vault)), 0, "base asset balance should be zero");
 
         assertEq(
@@ -819,8 +819,8 @@ abstract contract VaultDeposit is VaultSharedSetup {
         // 3e18 gets spread out equally amongst the three pools
         vault.deposit(depositAmount, address(this));
 
-        assertEq(vault.totalSupply(), depositAmount, "vault shares total supply");
-        assertEq(vault.balanceOf(address(this)), depositAmount, "user vault shares balance");
+        assertEq(_convertTo18(vault.totalSupply()), depositAmount, "vault shares total supply");
+        assertEq(_convertTo18(vault.balanceOf(address(this))), depositAmount, "user vault shares balance");
         assertEq(BASE_ASSET.balanceOf(address(vault)), 0, "base asset balance should be zero");
 
         assertEq(
@@ -856,8 +856,8 @@ abstract contract VaultDeposit is VaultSharedSetup {
 
         vault.deposit(depositAmount, address(this));
 
-        assertEq(vault.totalSupply(), depositAmount, "vault shares total supply");
-        assertEq(vault.balanceOf(address(this)), depositAmount, "user vault shares balance");
+        assertEq(_convertTo18(vault.totalSupply()), depositAmount, "vault shares total supply");
+        assertEq(_convertTo18(vault.balanceOf(address(this))), depositAmount, "user vault shares balance");
         assertEq(BASE_ASSET.balanceOf(address(vault)), 0, "base asset balance should be zero");
 
         assertEq(
@@ -988,7 +988,7 @@ abstract contract VaultDeposit is VaultSharedSetup {
      * converting the shares to assets.
      */
     function test_Mint_WithoutSupplyCap_WithoutAllocationCap() public {
-        uint256 sharesToMint = 1e18;
+        uint256 sharesToMint = 1e18; // Shares is 22 decimals so technically 0.0001 shares
 
         setERC20Balance(address(BASE_ASSET), address(this), 100e18);
 
@@ -1005,6 +1005,12 @@ abstract contract VaultDeposit is VaultSharedSetup {
         uint256 assetsDeposited = vault.mint(sharesToMint, address(this));
 
         uint256 assetBalanceDiff = initialAssetBalance - BASE_ASSET.balanceOf(address(this));
+
+        console2.log("vault.decimals(): ", vault.decimals());
+        console2.log("vault.totalSupply(): ", vault.totalSupply());
+        console2.log("initialTotalSupply: ", initialTotalSupply);
+        console2.log("vault.totalAssets(): ", vault.totalAssets());
+        console2.log("initialTotalAssets: ", initialTotalAssets);
         uint256 totalSupplyDiff = vault.totalSupply() - initialTotalSupply;
         uint256 totalAssetsDiff = vault.totalAssets() - initialTotalAssets;
 
@@ -1166,8 +1172,9 @@ abstract contract VaultWithdraw is VaultSharedSetup {
         uint256 expectedNewTotalAssets = prevTotalAssets - withdrawAmount;
         uint256 expectedMaxWithdraw = prevMaxWithdraw - withdrawAmount;
 
-        uint256 expectedSharesBurned =
-            withdrawAmount.mulDiv(prevTotalSupply + 1, prevTotalAssets + 1, Math.Rounding.Ceil);
+        uint256 expectedSharesBurned = withdrawAmount.mulDiv(
+            prevTotalSupply + 10 ** vault.DECIMALS_OFFSET(), prevTotalAssets + 1, Math.Rounding.Ceil
+        );
         uint256 expectedNewTotalSupply = prevTotalSupply - expectedSharesBurned;
 
         // vault
@@ -1217,8 +1224,9 @@ abstract contract VaultWithdraw is VaultSharedSetup {
         uint256 expectedNewTotalAssets = prevTotalAssets - withdrawAmount;
         uint256 expectedMaxWithdraw = prevMaxWithdraw - withdrawAmount;
 
-        uint256 expectedSharesBurned =
-            withdrawAmount.mulDiv(prevTotalSupply + 1, prevTotalAssets + 1, Math.Rounding.Ceil);
+        uint256 expectedSharesBurned = withdrawAmount.mulDiv(
+            prevTotalSupply + 10 ** vault.DECIMALS_OFFSET(), prevTotalAssets + 1, Math.Rounding.Ceil
+        );
         uint256 expectedNewTotalSupply = prevTotalSupply - expectedSharesBurned;
 
         // error bound for resulting total assets after a withdraw
@@ -2002,9 +2010,9 @@ contract VaultERC4626ExternalViews is VaultSharedSetup {
         uint256 maxWithdrawableAssets = vault.previewRedeem(resultingShares);
         uint256 maxRedeemableShares = vault.previewWithdraw(maxWithdrawableAssets);
 
-        assertEq(resultingShares, 60e18, "resulting shares");
+        assertEq(_convertTo18(resultingShares), 60e18, "resulting shares");
         assertEq(maxWithdrawableAssets, 60e18, "resulting claim");
-        assertEq(maxRedeemableShares, 60e18, "redeemable shares");
+        assertEq(_convertTo18(maxRedeemableShares), 60e18, "redeemable shares");
     }
 
     function test_MaxWithdraw() public { }


### PR DESCRIPTION
### H-02
- [x] Adds the hard-coded 4 extra precision through `DECIMALS_OFFSET`
- [x] Removes the burning of 1e3 initial shares from the `VaultFactory`. The factory now only deploys the bytecode with a salt and does nothing else.
- [x] Tests were modified to account for the fact that shares now have 22 decimals (18 decimals for ETH-correlated underlying assets and 4 extra).  