### PR TITLE
[OZ] H-01

### DIFF
--- a/src/token/RewardToken.sol
+++ b/src/token/RewardToken.sol
@@ -321,7 +321,7 @@ abstract contract RewardToken is
 
         RewardTokenStorage storage $ = _getRewardTokenStorage();
 
-        uint256 _supplyFactor = $.supplyFactor;
+        uint256 _supplyFactor = supplyFactor();
         uint256 amountNormalized = amount.rayDivDown(_supplyFactor);
 
         uint256 oldSenderBalance = $._normalizedBalances[from];


### PR DESCRIPTION
### H-01 
- On `_transfer`, when calculating the amount of `normalizedBalance` to transfer with `supplyFactor`, it now includes the accrued per-second interest rate in the `supplyFactor`. 
- Instead of directly querying the `$._supplyFactor`, it uses the `supplyFactor` view function which includes the "to-be-accrued" interest rate.
- View function called rather than `_accrueInterest` for gas savings. The `_accrueInterest` MUST be called if the function changes the utilization rate of the pool, but `_transfer` does not. 