### PR TITLE
[OZ] L-01

### DIFF
--- a/src/vault/Vault.sol
+++ b/src/vault/Vault.sol
@@ -577,9 +577,6 @@ contract Vault is ERC4626, Multicall, AccessControlDefaultAdminRules, Reentrancy
     function mint(uint256 shares, address receiver) public override nonReentrant returns (uint256 assets) {
         uint256 newTotalAssets = _accrueFee();
 
-        // This is updated again with the deposited assets amount in `_deposit`.
-        lastTotalAssets = newTotalAssets;
-
         assets = _convertToAssetsWithTotals(shares, totalSupply(), newTotalAssets, Math.Rounding.Ceil);
 
         _deposit(_msgSender(), receiver, assets, shares);
@@ -837,7 +834,7 @@ contract Vault is ERC4626, Multicall, AccessControlDefaultAdminRules, Reentrancy
         (feeShares, newTotalAssets) = _accruedFeeShares();
         if (feeShares != 0) _mint(feeRecipient, feeShares);
 
-        lastTotalAssets = newTotalAssets;
+        _updateLastTotalAssets(newTotalAssets);
 
         emit FeeAccrued(feeShares, newTotalAssets);
     }


### PR DESCRIPTION
### L-01
- [x] Use _updateLastTotalAssets() instead of direct storage update for consistency
- [x] Remove redundant update in `mint`